### PR TITLE
V2.1.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Added option `justNow` that prints `Just now` if time is within 60 minutes;
 - Added option `noSuffix` that removes `ago` from the printed result;
+- Added more info to `OPTIONS.md` documentation file;
 
 ----
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## v2.1.1 (2022-01-28)
 
 - Added option `justNow` that prints `Just now` if time is within 60 minutes;
+- Added option `noSuffix` that removes `ago` from the printed result;
 
 ----
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ----
 
+## v2.1.1 (2022-01-28)
+
+- Added option `justNow` that prints `Just now` if time is within 60 minutes;
+
+----
+
 ## v2.1.0 (2022-01-27)
 
 - Changed:

--- a/docs/OPTIONS.md
+++ b/docs/OPTIONS.md
@@ -10,9 +10,15 @@
 As the seconds argument `Parse()` method excepts strings. Here is an example of passed option.
 
 ```go
-timeago.Parse(time.Now(), "online") // Online
-timeago.Parse(time.Now()) // 0 seconds ago
-timeago.Parse(time.Now(), "justNow") // Just now
+currentTime := time.Now()
+hourAgo := currentTime.Add(-time.Hour)
+
+timeago.Parse(currentTime) // 0 seconds ago
+timeago.Parse(currentTime, "online") // Online
+timeago.Parse(currentTime, "justNow") // Just now
+
+timeago.Parse(hourAgo) // 1 hour ago
+timeago.Parse(hourAgo, "noSuffix") // 1 hour
 ```
 
 ## Available options
@@ -21,8 +27,6 @@ timeago.Parse(time.Now(), "justNow") // Just now
 | --- | --- |
 | `online` | Displays **Online** if date interval withing 60 seconds. For example instead if `13 seconds ago` prints `Online` |
 | `justNow` | Displays **Just now** if date interval withing 60 seconds. For example instead of `32 seconds ago` prints `Just now`. |
-
-> More options are coming in the next versions.
-
+| `noSuffix` | Removes suffix from datetime result and get for example "5 minutes" instead of "5 minutes ago". |
 
 [<< Go back to home](https://github.com/SerhiiCho/timeago/blob/master/README.md)

--- a/docs/OPTIONS.md
+++ b/docs/OPTIONS.md
@@ -10,15 +10,17 @@
 As the seconds argument `Parse()` method excepts strings. Here is an example of passed option.
 
 ```go
-timeago.Parse(time.Now(), "online") // output: Online
-timeago.Parse(time.Now()) // output: 0 seconds ago
+timeago.Parse(time.Now(), "online") // Online
+timeago.Parse(time.Now()) // 0 seconds ago
+timeago.Parse(time.Now(), "justNow") // Just now
 ```
 
 ## Available options
 
 | Option | Description |
 | --- | --- |
-| `online` | Displays **Online** if date interval withing 60 seconds. |
+| `online` | Displays **Online** if date interval withing 60 seconds. For example instead if `13 seconds ago` prints `Online` |
+| `justNow` | Displays **Just now** if date interval withing 60 seconds. For example instead of `32 seconds ago` prints `Just now`. |
 
 > More options are coming in the next versions.
 

--- a/docs/OPTIONS.md
+++ b/docs/OPTIONS.md
@@ -1,6 +1,8 @@
 [<< Go back to home](https://github.com/SerhiiCho/timeago/blob/master/README.md)
 
 - [Usage](#usage)
+- [Example with one option](#example-with-one-option)
+- [Example with multiple options](#example-with-multiple-options)
 - [Available options](#available-options)
 
 # 🤲 Options
@@ -9,16 +11,25 @@
 
 As the seconds argument `Parse()` method excepts strings. Here is an example of passed option.
 
+## Example with one option
+
 ```go
 currentTime := time.Now()
 hourAgo := currentTime.Add(-time.Hour)
 
-timeago.Parse(currentTime) // 0 seconds ago
 timeago.Parse(currentTime, "online") // Online
 timeago.Parse(currentTime, "justNow") // Just now
-
-timeago.Parse(hourAgo) // 1 hour ago
 timeago.Parse(hourAgo, "noSuffix") // 1 hour
+```
+
+## Example with multiple options
+
+```go
+currentTime := time.Now()
+hourAgo := currentTime.Add(-time.Hour)
+
+timeago.Parse(currentTime, "online", "noSuffix") // Online
+timeago.Parse(hourAgo, "online", "noSuffix") // 1 hour
 ```
 
 ## Available options

--- a/lang.go
+++ b/lang.go
@@ -10,6 +10,7 @@ import (
 type lang struct {
 	Ago            string
 	Online         string
+	JustNow        string
 	Second         string
 	Seconds        string
 	SecondsSpecial string

--- a/langs/en.json
+++ b/langs/en.json
@@ -1,6 +1,7 @@
 {
     "Ago": "ago",
     "Online": "Online",
+    "JustNow": "Just now",
     "Second": "second",
     "Seconds": "seconds",
     "Minute": "minute",

--- a/langs/nl.json
+++ b/langs/nl.json
@@ -1,6 +1,7 @@
 {
     "Ago": "geleden",
     "Online": "Online",
+    "JustNow": "Net nu",
     "Second": "seconde",
     "Seconds": "seconden",
     "Minute": "minuut",

--- a/langs/ru.json
+++ b/langs/ru.json
@@ -1,6 +1,7 @@
 {
     "Ago": "назад",
     "Online": "В сети",
+    "JustNow": "Только что",
     "Second": "секунда",
     "Seconds": "секунды",
     "SecondsSpecial": "секунд",

--- a/langs/uk.json
+++ b/langs/uk.json
@@ -1,6 +1,7 @@
 {
     "Ago": "тому",
     "Online": "В мережі",
+    "JustNow": "Щойно",
     "Second": "секунда",
     "Seconds": "секунди",
     "SecondsSpecial": "секунд",

--- a/tests/just_now_test.go
+++ b/tests/just_now_test.go
@@ -1,0 +1,77 @@
+package tests
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/SerhiiCho/timeago"
+)
+
+func TestParseWithJustNowFlag(t *testing.T) {
+	type TestCase struct {
+		date   time.Time
+		result string
+	}
+
+	cases := []TestCase{
+		{subMinutes(1), "1 minute ago"},
+		{subMinutes(2), "2 minutes ago"},
+		{subMinutes(3), "3 minutes ago"},
+		{subMinutes(4), "4 minutes ago"},
+		{subMinutes(5), "5 minutes ago"},
+		{subMinutes(10), "10 minutes ago"},
+		{subMinutes(11), "11 minutes ago"},
+		{subMinutes(20), "20 minutes ago"},
+		{subMinutes(21), "21 minutes ago"},
+		{subMinutes(22), "22 minutes ago"},
+		{subMinutes(30), "30 minutes ago"},
+		{subMinutes(31), "31 minutes ago"},
+		{subHours(1), "1 hour ago"},
+		{subHours(2), "2 hours ago"},
+		{subHours(9), "9 hours ago"},
+		{subHours(10), "10 hours ago"},
+		{subHours(11), "11 hours ago"},
+		{subHours(20), "20 hours ago"},
+		{subHours(21), "21 hours ago"},
+		{subHours(23), "23 hours ago"},
+		{subDays(1), "1 day ago"},
+		{subDays(2), "2 days ago"},
+		{subDays(6), "6 days ago"},
+		{subWeeks(1), "1 week ago"},
+		{subWeeks(2), "2 weeks ago"},
+		{subWeeks(3), "3 weeks ago"},
+		{subMonths(1), "1 month ago"},
+		{subMonths(2), "2 months ago"},
+		{subMonths(3), "3 months ago"},
+		{subMonths(4), "4 months ago"},
+		{subMonths(5), "5 months ago"},
+		{subMonths(6), "6 months ago"},
+		{subMonths(7), "7 months ago"},
+		{subMonths(8), "8 months ago"},
+		{subMonths(9), "9 months ago"},
+		{subMonths(10), "10 months ago"},
+		{subMonths(11), "11 months ago"},
+		{subMonths(12), "1 year ago"},
+		{subYears(4), "4 years ago"},
+		{subYears(5), "5 years ago"},
+		{subYears(11), "11 years ago"},
+		{subYears(29), "29 years ago"},
+		{subYears(92), "92 years ago"},
+	}
+
+	for i := 0; i < 60; i++ {
+		cases = append(cases, TestCase{subSeconds(time.Duration(i)), "Just now"})
+	}
+
+	for _, tc := range cases {
+		t.Run("result for "+tc.date.String(), func(test *testing.T) {
+			SetConfig(Config{
+				Language: langEn,
+			})
+
+			if res := Parse(tc.date, "justNow"); res != tc.result {
+				test.Errorf("Result must be %s, but got %s instead", tc.result, res)
+			}
+		})
+	}
+}

--- a/tests/multiple_options_test.go
+++ b/tests/multiple_options_test.go
@@ -1,0 +1,54 @@
+package tests
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/SerhiiCho/timeago"
+)
+
+func TestParseWithMultipleFlags(t *testing.T) {
+	type TestCase struct {
+		date   time.Time
+		result string
+	}
+
+	cases := []TestCase{
+		{subMinutes(1), "1 minute"},
+		{subMinutes(5), "5 minutes"},
+		{subMinutes(10), "10 minutes"},
+		{subMinutes(30), "30 minutes"},
+		{subMinutes(31), "31 minutes"},
+		{subHours(1), "1 hour"},
+		{subHours(11), "11 hours"},
+		{subHours(20), "20 hours"},
+		{subDays(6), "6 days"},
+		{subWeeks(1), "1 week"},
+		{subWeeks(2), "2 weeks"},
+		{subWeeks(3), "3 weeks"},
+		{subMonths(1), "1 month"},
+		{subMonths(6), "6 months"},
+		{subMonths(8), "8 months"},
+		{subMonths(9), "9 months"},
+		{subMonths(11), "11 months"},
+		{subMonths(1), "1 month"},
+		{subYears(2), "2 years"},
+		{subYears(44), "44 years"},
+	}
+
+	for i := 0; i < 60; i++ {
+		cases = append(cases, TestCase{subSeconds(time.Duration(i)), "Online"})
+	}
+
+	for _, tc := range cases {
+		t.Run("result for "+tc.date.String(), func(test *testing.T) {
+			SetConfig(Config{
+				Language: langEn,
+			})
+
+			if res := Parse(tc.date, "online", "noSuffix"); res != tc.result {
+				test.Errorf("Result must be %s, but got %s instead", tc.result, res)
+			}
+		})
+	}
+}

--- a/tests/no_suffix_test.go
+++ b/tests/no_suffix_test.go
@@ -1,0 +1,79 @@
+package tests
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/SerhiiCho/timeago"
+)
+
+func TestParseWithNoSuffixFlag(t *testing.T) {
+	type TestCase struct {
+		date   time.Time
+		result string
+		lang   string
+	}
+
+	cases := []TestCase{
+		{subMinutes(1), "1 minute", "en"},
+		{subMinutes(2), "2 minutes", "en"},
+		{subMinutes(3), "3 minutes", "en"},
+		{subMinutes(4), "4 minutes", "en"},
+		{subMinutes(5), "5 minutes", "en"},
+		{subMinutes(10), "10 minutes", "en"},
+		{subMinutes(11), "11 minutes", "en"},
+		{subMinutes(20), "20 minutes", "en"},
+		{subMinutes(21), "21 minutes", "en"},
+		{subMinutes(22), "22 minutes", "en"},
+		{subMinutes(30), "30 minutes", "en"},
+		{subMinutes(31), "31 minutes", "en"},
+		{subHours(1), "1 hour", "en"},
+		{subHours(2), "2 hours", "en"},
+		{subHours(9), "9 hours", "en"},
+		{subHours(10), "10 hours", "en"},
+		{subHours(11), "11 hours", "en"},
+		{subHours(20), "20 hours", "en"},
+		{subHours(21), "21 hours", "en"},
+		{subHours(23), "23 hours", "en"},
+		{subDays(1), "1 day", "en"},
+		{subDays(2), "2 days", "en"},
+		{subDays(6), "6 days", "en"},
+		{subWeeks(1), "1 week", "en"},
+		{subWeeks(2), "2 weeks", "en"},
+		{subWeeks(3), "3 weeks", "en"},
+		{subMonths(1), "1 month", "en"},
+		{subMonths(2), "2 months", "en"},
+		{subMonths(3), "3 months", "en"},
+		{subMonths(4), "4 months", "en"},
+		{subMonths(5), "5 months", "en"},
+		{subMonths(6), "6 months", "en"},
+		{subMonths(7), "7 months", "en"},
+		{subMonths(8), "8 months", "en"},
+		{subMonths(9), "9 months", "en"},
+		{subMonths(10), "10 months", "en"},
+		{subMonths(11), "11 months", "en"},
+		{subMonths(12), "1 year", "en"},
+		{subYears(4), "4 years", "en"},
+		{subYears(5), "5 years", "en"},
+		{subYears(11), "11 years", "en"},
+		{subYears(29), "29 years", "en"},
+		{subYears(92), "92 years", "en"},
+		{subMinutes(1), "1 минута", "ru"},
+		{subMinutes(2), "2 минуты", "ru"},
+		{subMonths(3), "3 месяца", "ru"},
+		{subWeeks(2), "2 недели", "ru"},
+		{subYears(77), "77 лет", "ru"},
+	}
+
+	for _, tc := range cases {
+		t.Run("result for "+tc.date.String(), func(test *testing.T) {
+			SetConfig(Config{
+				Language: tc.lang,
+			})
+
+			if res := Parse(tc.date, "noSuffix"); res != tc.result {
+				test.Errorf("Result must be %s, but got %s instead", tc.result, res)
+			}
+		})
+	}
+}

--- a/timeago.go
+++ b/timeago.go
@@ -117,8 +117,13 @@ func getWords(timeKind string, num int) string {
 	time := getTimeTranslations()
 
 	translation := time[timeKind][form]
+	result := strconv.Itoa(num) + " " + translation
 
-	return strconv.Itoa(num) + " " + translation + " " + trans().Ago
+	if optionIsEnabled("noSuffix") {
+		return result
+	}
+
+	return result + " " + trans().Ago
 }
 
 // Check if option was passed by a Parse function

--- a/timeago.go
+++ b/timeago.go
@@ -75,6 +75,8 @@ func calculateTheResult(seconds int) string {
 	switch {
 	case optionIsEnabled("online") && seconds < 60:
 		return trans().Online
+	case optionIsEnabled("justNow") && seconds < 60:
+		return trans().JustNow
 	case seconds < 60:
 		return getWords("seconds", seconds)
 	case minutes < 60:


### PR DESCRIPTION
- Added option `justNow` that prints `Just now` if time is within 60 minutes;
- Added option `noSuffix` that removes `ago` from the printed result;
- Added more info to `OPTIONS.md` documentation file;