### PR TITLE
refactor(lang): do not print number when getting form

### DIFF
--- a/lang.go
+++ b/lang.go
@@ -79,7 +79,6 @@ func getTimeTranslations() map[string]map[string]string {
 }
 
 func getLanguageForm(num int) string {
-	fmt.Printf("%#v\n", num)
 	lastDigit := getLastNumberDigit(num)
 	rule := getRules(num, lastDigit)[config.Language]
 


### PR DESCRIPTION
Hey there!

I wanted to use this library for a small personal project that uses bubbletea. The library is great and works like a charm! I can even provide the french translations if you'd like.

But I have a tiny issue with it: when parsing the form, it prints the number which messes my tui application (tui applications really don't like it when you print to stdout). I think it's just a small debug log that was left behind and is not intended.

Cheers!