### PR TITLE
Update package namespace

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go_version: ['1.20', '1.21']
+        go_version: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.21']
 
     steps:
     - name: Check out code into the Go module directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
-[<< Go back to home](https://github.com/SerhiiCho/timeago/blob/master/README.md)
-
 # 🗒 Release Notes
+
+----
+
+## v2.1.11 (2023-12-26)
+
+- Update Go version in `go.mod` to `1.13`
+- Change package namespace to `github.com/SerhiiCho/timeago/v2` to match Go versioning rules
 
 ----
 
@@ -184,7 +189,3 @@
 ## v1.1.2 (2021-11-28)
 
 - Fixed bug with wrong path for plugin root
-
-----
-
-[<< Go back to home](https://github.com/SerhiiCho/timeago/blob/master/README.md)

--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ Fast and lightweight date time package that converts given date into "n time ago
 ## 🚀 Quick Start
 
 ```bash
-go get -u github.com/SerhiiCho/timeago
+go get github.com/SerhiiCho/timeago/v2
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/SerhiiCho/timeago
+module github.com/SerhiiCho/timeago/v2
 
-go 1.20
+go 1.13

--- a/tests/en_test.go
+++ b/tests/en_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/SerhiiCho/timeago"
+	. "github.com/SerhiiCho/timeago/v2"
 )
 
 const langEn = "en"

--- a/tests/just_now_test.go
+++ b/tests/just_now_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/SerhiiCho/timeago"
+	. "github.com/SerhiiCho/timeago/v2"
 )
 
 func TestParseWithJustNowFlag(t *testing.T) {

--- a/tests/multiple_options_test.go
+++ b/tests/multiple_options_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/SerhiiCho/timeago"
+	. "github.com/SerhiiCho/timeago/v2"
 )
 
 func TestParseWithMultipleFlags(t *testing.T) {

--- a/tests/nl_test.go
+++ b/tests/nl_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/SerhiiCho/timeago"
+	. "github.com/SerhiiCho/timeago/v2"
 )
 
 const langNl = "nl"

--- a/tests/no_suffix_test.go
+++ b/tests/no_suffix_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/SerhiiCho/timeago"
+	. "github.com/SerhiiCho/timeago/v2"
 )
 
 func TestParseWithNoSuffixFlag(t *testing.T) {

--- a/tests/online_test.go
+++ b/tests/online_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/SerhiiCho/timeago"
+	. "github.com/SerhiiCho/timeago/v2"
 )
 
 func TestParseWithOnlineFlag(t *testing.T) {

--- a/tests/ru_test.go
+++ b/tests/ru_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/SerhiiCho/timeago"
+	. "github.com/SerhiiCho/timeago/v2"
 )
 
 const langRu = "ru"

--- a/tests/uk_test.go
+++ b/tests/uk_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/SerhiiCho/timeago"
+	. "github.com/SerhiiCho/timeago/v2"
 )
 
 const langUk = "uk"


### PR DESCRIPTION
- Update Go version in `go.mod` to `1.13`
- Change package namespace to `github.com/SerhiiCho/timeago/v2` to match Go versioning rules