### PR TITLE
V3.1.0

### DIFF
--- a/.github/CHANGELOGV1.md
+++ b/.github/CHANGELOGV1.md
@@ -1,0 +1,25 @@
+# Release Notes v1
+
+## v1.1.8 (2022-01-16)
+- Improved documentation for the package
+
+## v1.1.7 (2022-01-16)
+- Added caching the parsed results into memory to speed up the program. After this change, it will only parse json files once
+
+## v1.1.6 (2021-12-30)
+- Changed type for the special rule in `rules.go` file
+- Improved docs by adding more information about how to contribute a language support
+
+## v1.1.5 (2021-12-22)
+- Added support for Ukrainian language
+- Improved documentation
+- Made easy to contribute another language
+
+## v1.1.4 (2021-12-05)
+- Fixed mistake with failing test
+
+## v1.1.3 (2021-12-04)
+- Added ability to add rules to a language. We need it in order to make ability easily add a new translation for the package. Each language will have it's own set of rules
+
+## v1.1.2 (2021-11-28)
+- Fixed bug with wrong path for plugin root

--- a/.github/CHANGELOGV2.md
+++ b/.github/CHANGELOGV2.md
@@ -1,0 +1,104 @@
+# Release Notes v2
+
+## v2.2.1 (2024-03-28)
+- Updated `README.md` file by adding more information about supported languages
+- Formatted `CHANGELOG.md` file
+- Added more tests
+
+## v2.2.0 (2024-03-08)
+- Added the German 🇩🇪 language support
+- Formatted `CHANGELOG.md` file
+
+## v2.1.11 (2023-12-26)
+- Updated Go version in `go.mod` to `1.13`
+- Changed package namespace to `github.com/SerhiiCho/timeago/v2` to match Go versioning rules
+
+## v2.1.10 (2023-12-26)
+- Updated Go version in `go.mod` from `1.13` to `1.21.0`
+
+## v2.1.9 (2023-12-26)
+- Updated `CHANGELOG.md` file
+
+## v2.1.8 (2023-12-03)
+- Removed printing number getting form. [Commit](https://github.com/SerhiiCho/timeago/commit/52b312ad4a64c7ca9ef0d08e0920986c69ae610e)
+
+## v2.1.7 (2023-09-08)
+- Renamed master branch to main
+- Added more tests
+- Simplified code
+- Replaced deprecated `ioutil.ReadFile` with `os.ReadFile`
+
+## v2.1.6 (2022-11-27)
+- Changed typo in README.md file
+- Added ability to overwrite output strings for custom values
+
+## v2.1.5 (2022-10-09)
+- Code base refactoring. Made source code look nicer
+
+## v2.1.4 (2022-10-04)
+- Code base refactoring. Made source code look nicer
+
+## v2.1.3 (2022-06-11)
+- Documentation improvements and small changes
+- Fixed bug in test file `tests/utils.go` related to not properly counting months and years when testing
+- Added link to `README.md` file
+
+## v2.1.2 (2022-01-28)
+- Added so that `Parse` function can except not only past date but also future date and return correct result. Closes #23
+- Added section `12 Features` to the `README.md`
+
+## v2.1.1 (2022-01-28)
+- Added option `justNow` that prints `Just now` if time is within 60 minutes
+- Added option `noSuffix` that removes `ago` from the printed result
+- Added more info to `OPTIONS.md` documentation file
+
+## v2.1.0 (2022-01-27)
+- Changed:
+    - Renamed `Lang` structure to `lang` to make it private
+    - Renamed `Rule` structure to `rule` to make it private
+    - Changed location configurations. Now package can work without location configuration
+- Removed:
+    - Removed badge from `README.md` file
+    - Removed tests from language files and added 1 test to `online_test.go` file
+
+## v2.0.4 (2022-01-22)
+- Added:
+    - Added anchors to "Contribute translation" docs
+    - Added 2 new GitHub badges
+    - Added more tests and test coverage
+- Changed:
+    - Improved tests for languages by changing the way to write them
+- Fixed:
+    - Fixed mistakes in Ukrainian 🇺🇦 language translation
+
+## v2.0.3 (2022-01-22)
+- Added support for Dutch 🇳🇱 language
+
+## v2.0.2 (2022-01-21)
+- Fixed typo in docs
+- Added more info to `contribute a translation guide`
+
+## v2.0.1 (2022-01-20)
+- Fixed:
+    - Fixed not working anchor tag in `OPTIONS.md` file
+- Added:
+    - Added emoji to Release notes title in `CHANGELOG.md`
+    - Added `.gitattributes` file
+    - Added Example usage on `repl.it` website
+    - Added nice image banner to `README.md` file
+
+## v2.0.0 (2022-01-19)
+- Added:
+    - Added ability for `Parse` method to except unix timestamp
+    - Added ability for `Parse` method to except `Time` from Go time package
+- Changed:
+    - Renamed `Take` method to `Parse`
+    - Changed the way you pass options
+    - Renamed `Set` method to `SetConfig`
+    - Changed the way you set configurations for the package
+- Documentation:
+    - Added more information to docs
+    - Added `docs` directory with all the docs
+    - Changed structure of the `CHANGELOG.md`
+- Other:
+    - Refactored and rewritten code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## v3.1.0 (2024-11-25)
 - Updated the `LICENSE.md` file
 - Refactored codebase to make it more readable and maintainable
-- Added `OnlineThreshold` parameter to the configurations to set the threshold for the "Online" status
-- Added `JustNowThreshold` parameter to the configurations to set the threshold for the "Just now" status
+- Added [OnlineThreshold](https://time-ago.github.io/v3/configurations.html#thresholds) parameter to the configurations to set the threshold for the "Online" status
+- Added [JustNowThreshold](https://time-ago.github.io/v3/configurations.html#thresholds) parameter to the configurations to set the threshold for the "Just now" status
 - **POTENTIAL BREAK**. Might break your code if you were using the `Option` type or option constants directly. Which wasn't documented for public use.
     - Rename `Option` type to `opt` making it unexported
     - Add prefix to option constants `Opt` to make them like `OptOnline`, `OptNoSuffix`, etc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v3.1.0 (2024-11-25)
 - Updated the `LICENSE.md` file
+- Refactored codebase to make it more readable and maintainable
 
 ## v3.0.0 (2024-11-22)
 > BREAKING CHANGES!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Refactored codebase to make it more readable and maintainable
 - Added [OnlineThreshold](https://time-ago.github.io/v3/configurations.html#thresholds) parameter to the configurations to set the threshold for the "Online" status
 - Added [JustNowThreshold](https://time-ago.github.io/v3/configurations.html#thresholds) parameter to the configurations to set the threshold for the "Just now" status
+- Added support for Chinese Simplified language 🇨🇳
 - **POTENTIAL BREAK**. Might break your code if you were using the `Option` type or option constants directly. Which wasn't documented for public use.
     - Rename `Option` type to `opt` making it unexported
     - Add prefix to option constants `Opt` to make them like `OptOnline`, `OptNoSuffix`, etc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v3.1.0 (2024-11-25)
 - Updated the `LICENSE.md` file
 - Refactored codebase to make it more readable and maintainable
+- Added `OnlineThreshold` parameter to the configurations to set the threshold for the "Online" status
+- Added `JustNowThreshold` parameter to the configurations to set the threshold for the "Just now" status
 - **POTENTIAL BREAK**. Might break your code if you were using the `Option` type or option constants directly. Which wasn't documented for public use.
     - Rename `Option` type to `opt` making it unexported
     - Add prefix to option constants `Opt` to make them like `OptOnline`, `OptNoSuffix`, etc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# 🗒 Release Notes
+# Release Notes v3
+
+## v3.1.0 (2024-11-25)
+- Updated the `LICENSE.md` file
 
 ## v3.0.0 (2024-11-22)
 > BREAKING CHANGES!
@@ -13,129 +16,6 @@
 
 > Follow the [Upgrade Guide](https://time-ago.github.io/upgrade.html) from v2 to v3
 
-## v2.2.1 (2024-03-28)
-- Updated `README.md` file by adding more information about supported languages
-- Formatted `CHANGELOG.md` file
-- Added more tests
 
-## v2.2.0 (2024-03-08)
-- Added the German 🇩🇪 language support
-- Formatted `CHANGELOG.md` file
-
-## v2.1.11 (2023-12-26)
-- Updated Go version in `go.mod` to `1.13`
-- Changed package namespace to `github.com/SerhiiCho/timeago/v2` to match Go versioning rules
-
-## v2.1.10 (2023-12-26)
-- Updated Go version in `go.mod` from `1.13` to `1.21.0`
-
-## v2.1.9 (2023-12-26)
-- Updated `CHANGELOG.md` file
-
-## v2.1.8 (2023-12-03)
-- Removed printing number getting form. [Commit](https://github.com/SerhiiCho/timeago/commit/52b312ad4a64c7ca9ef0d08e0920986c69ae610e)
-
-## v2.1.7 (2023-09-08)
-- Renamed master branch to main
-- Added more tests
-- Simplified code
-- Replaced deprecated `ioutil.ReadFile` with `os.ReadFile`
-
-## v2.1.6 (2022-11-27)
-- Changed typo in README.md file
-- Added ability to overwrite output strings for custom values
-
-## v2.1.5 (2022-10-09)
-- Code base refactoring. Made source code look nicer
-
-## v2.1.4 (2022-10-04)
-- Code base refactoring. Made source code look nicer
-
-## v2.1.3 (2022-06-11)
-- Documentation improvements and small changes
-- Fixed bug in test file `tests/utils.go` related to not properly counting months and years when testing
-- Added link to `README.md` file
-
-## v2.1.2 (2022-01-28)
-- Added so that `Parse` function can except not only past date but also future date and return correct result. Closes #23
-- Added section `12 Features` to the `README.md`
-
-## v2.1.1 (2022-01-28)
-- Added option `justNow` that prints `Just now` if time is within 60 minutes
-- Added option `noSuffix` that removes `ago` from the printed result
-- Added more info to `OPTIONS.md` documentation file
-
-## v2.1.0 (2022-01-27)
-- Changed:
-    - Renamed `Lang` structure to `lang` to make it private
-    - Renamed `Rule` structure to `rule` to make it private
-    - Changed location configurations. Now package can work without location configuration
-- Removed:
-    - Removed badge from `README.md` file
-    - Removed tests from language files and added 1 test to `online_test.go` file
-
-## v2.0.4 (2022-01-22)
-- Added:
-    - Added anchors to "Contribute translation" docs
-    - Added 2 new GitHub badges
-    - Added more tests and test coverage
-- Changed:
-    - Improved tests for languages by changing the way to write them
-- Fixed:
-    - Fixed mistakes in Ukrainian 🇺🇦 language translation
-
-## v2.0.3 (2022-01-22)
-- Added support for Dutch 🇳🇱 language
-
-## v2.0.2 (2022-01-21)
-- Fixed typo in docs
-- Added more info to `contribute a translation guide`
-
-## v2.0.1 (2022-01-20)
-- Fixed:
-    - Fixed not working anchor tag in `OPTIONS.md` file
-- Added:
-    - Added emoji to Release notes title in `CHANGELOG.md`
-    - Added `.gitattributes` file
-    - Added Example usage on `repl.it` website
-    - Added nice image banner to `README.md` file
-
-## v2.0.0 (2022-01-19)
-- Added:
-    - Added ability for `Parse` method to except unix timestamp
-    - Added ability for `Parse` method to except `Time` from Go time package
-- Changed:
-    - Renamed `Take` method to `Parse`
-    - Changed the way you pass options
-    - Renamed `Set` method to `SetConfig`
-    - Changed the way you set configurations for the package
-- Documentation:
-    - Added more information to docs
-    - Added `docs` directory with all the docs
-    - Changed structure of the `CHANGELOG.md`
-- Other:
-    - Refactored and rewritten code
-
-## v1.1.8 (2022-01-16)
-- Improved documentation for the package
-
-## v1.1.7 (2022-01-16)
-- Added caching the parsed results into memory to speed up the program. After this change, it will only parse json files once
-
-## v1.1.6 (2021-12-30)
-- Changed type for the special rule in `rules.go` file
-- Improved docs by adding more information about how to contribute a language support
-
-## v1.1.5 (2021-12-22)
-- Added support for Ukrainian language
-- Improved documentation
-- Made easy to contribute another language
-
-## v1.1.4 (2021-12-05)
-- Fixed mistake with failing test
-
-## v1.1.3 (2021-12-04)
-- Added ability to add rules to a language. We need it in order to make ability easily add a new translation for the package. Each language will have it's own set of rules
-
-## v1.1.2 (2021-11-28)
-- Fixed bug with wrong path for plugin root
+## [Release Notes v2](.github/CHANGELOGV2.md)
+## [Release Notes v1](.github/CHANGELOGV1.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## v3.1.0 (2024-11-25)
 - Updated the `LICENSE.md` file
 - Refactored codebase to make it more readable and maintainable
+- **POTENTIAL BREAK**. Might break your code if you were using the `Option` type or option constants directly. Which wasn't documented for public use.
+    - Rename `Option` type to `opt` making it unexported
+    - Add prefix to option constants `Opt` to make them like `OptOnline`, `OptNoSuffix`, etc.
 
 ## v3.0.0 (2024-11-22)
 > BREAKING CHANGES!

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 TIMEAGO authors
+Copyright (c) 2019 Serhii Chornenkyi (Serhii Cho)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/SerhiiCho/timeago/badges/quality-score.png?b=main)](https://scrutinizer-ci.com/g/SerhiiCho/timeago/?branch=main)
 [![GitHub](https://img.shields.io/github/license/SerhiiCho/timeago)](https://github.com/SerhiiCho/timeago/blob/main/LICENSE.md)
 
-Timeago is a fast and lightweight date time package that converts given date into human readable "n time ago" format in different languages, such as 🇬🇧 🇷🇺 🇺🇦 🇳🇱 🇩🇪. For more information you can read the [documentation](https://time-ago.github.io/).
+Timeago is a fast and lightweight date time package that converts given date into human readable "n time ago" format in different languages, such as 🇬🇧 🇷🇺 🇺🇦 🇳🇱 🇩🇪 🇨🇳. For more information you can read the [documentation](https://time-ago.github.io/).
 
 ### Follow the [Official documentation](https://time-ago.github.io/) for all the details
 - [🗒 Documentation](https://time-ago.github.io/)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/SerhiiCho/timeago/badges/quality-score.png?b=main)](https://scrutinizer-ci.com/g/SerhiiCho/timeago/?branch=main)
 [![GitHub](https://img.shields.io/github/license/SerhiiCho/timeago)](https://github.com/SerhiiCho/timeago/blob/main/LICENSE.md)
 
-Timeago is a fast and lightweight date time package that converts given date into human readable "n time ago" format in different languages, such as 🇷🇺 🇬🇧 🇳🇱 🇺🇦 🇩🇪. For more information you can read the [documentation](https://time-ago.github.io/).
+Timeago is a fast and lightweight date time package that converts given date into human readable "n time ago" format in different languages, such as 🇬🇧 🇷🇺 🇺🇦 🇳🇱 🇩🇪. For more information you can read the [documentation](https://time-ago.github.io/).
 
 ### Follow the [Official documentation](https://time-ago.github.io/) for all the details
 - [🗒 Documentation](https://time-ago.github.io/)

--- a/README.md
+++ b/README.md
@@ -9,16 +9,21 @@
 Timeago is a fast and lightweight date time package that converts given date into human readable "n time ago" format in different languages, such as 🇷🇺 🇬🇧 🇳🇱 🇺🇦 🇩🇪. For more information you can read the [documentation](https://time-ago.github.io/).
 
 ### Follow the [Official documentation](https://time-ago.github.io/) for all the details
-
 - [🗒 Documentation](https://time-ago.github.io/)
 - [🗒 Release notes](https://github.com/SerhiiCho/timeago/blob/main/CHANGELOG.md)
 
-## 🚀 Quick Start
-
+## Quick Start
 ```bash
 go get github.com/SerhiiCho/timeago/v3
 ```
 
-## 📄 License
+## Codebase naming
+Here are some of the naming conventions used in the codebase and their meanings for better understanding:
 
+- **time unit** - a single time unit like `second`, `seconds`, `minute`, `minutes`, etc.
+- **time number** - a number of time units like `1`, `2`, `3`, etc. in a string like `1 minute ago`, `2 minutes ago`, `3 minutes ago`, etc.
+- **suffix** - the suffix `ago` in the final output like `1 minute ago`, `2 minutes ago`, `3 minutes ago`, etc.
+- **time since** - the final output result like `2 minutes`, `3 minutes ago`, `Just now`, `Online`, `3 years ago` etc.
+
+## License
 This project is open-sourced software licensed under the [MIT license](https://github.com/SerhiiCho/timeago/blob/main/LICENSE.md).

--- a/config.go
+++ b/config.go
@@ -2,28 +2,46 @@ package timeago
 
 type Config struct {
 	// Language is an ISO 639 language code like en, ru, de, nl, etc.
-	// If Language is not set it will default to English "en".
+	// Default: "en".
 	Language string
 
 	// Location is the timezone location neeed for parsing
 	// string date like "2019-01-01 00:00:00" to time.Time.
 	// If Location is not set it will default to the server's.
-	// Example: "America/New_York", "Asia/China"
+	// Example: "America/New_York", "Europe/Moscow".
+	// Default: "UTC".
 	Location string
 
 	// Translations is a slice of language sets that can be used to
 	// overwrite the default translations. Read more about it in the docs
 	// https://time-ago.github.io/configurations.html#overwrite-translations
+	// Default: []LangSet{}
 	Translations []LangSet
+
+	// OnlineThreshold is the threshold in seconds to determine when
+	// Timeago should show "Online" instead of "X seconds ago". If the
+	// time difference is less than the threshold, it will show "Online".
+	// Minimum value: "1"
+	// Default: "60"
+	OnlineThreshold uint
+
+	// JustNowThreshold is the threshold in seconds to determine when
+	// Timeago should show "Just now" instead of "X seconds ago". If the
+	// time difference is less than the threshold, it will show "Just now".
+	// Minimum value: "1"
+	// Default: "60"
+	JustNowThreshold uint
 }
 
 // NewConfig creates a new Config instance with the given language, location
 // and language sets to overwrite the default translations.
-func NewConfig(lang, loc string, langSets []LangSet) *Config {
+func NewConfig(lang, loc string, langSets []LangSet, online, justNow uint) *Config {
 	return &Config{
-		Language:     lang,
-		Location:     loc,
-		Translations: langSets,
+		Language:         lang,
+		Location:         loc,
+		Translations:     langSets,
+		OnlineThreshold:  online,
+		JustNowThreshold: justNow,
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -46,5 +46,5 @@ func NewConfig(lang, loc string, langSets []LangSet, online, justNow int) *Confi
 }
 
 func (c Config) isLocationProvided() bool {
-	return c.Location != ""
+	return c.Location != "UTC" && c.Location != ""
 }

--- a/config.go
+++ b/config.go
@@ -6,6 +6,7 @@ const (
 	LangUk string = "uk"
 	LangNl string = "nl"
 	LangDe string = "de"
+	LangZh string = "zh"
 )
 
 type Config struct {

--- a/config.go
+++ b/config.go
@@ -23,19 +23,19 @@ type Config struct {
 	// time difference is less than the threshold, it will show "Online".
 	// Minimum value: "1"
 	// Default: "60"
-	OnlineThreshold uint
+	OnlineThreshold int
 
 	// JustNowThreshold is the threshold in seconds to determine when
 	// Timeago should show "Just now" instead of "X seconds ago". If the
 	// time difference is less than the threshold, it will show "Just now".
 	// Minimum value: "1"
 	// Default: "60"
-	JustNowThreshold uint
+	JustNowThreshold int
 }
 
 // NewConfig creates a new Config instance with the given language, location
 // and language sets to overwrite the default translations.
-func NewConfig(lang, loc string, langSets []LangSet, online, justNow uint) *Config {
+func NewConfig(lang, loc string, langSets []LangSet, online, justNow int) *Config {
 	return &Config{
 		Language:         lang,
 		Location:         loc,

--- a/config.go
+++ b/config.go
@@ -1,11 +1,19 @@
 package timeago
 
+const (
+	LangEn string = "en"
+	LangRu string = "ru"
+	LangUk string = "uk"
+	LangNl string = "nl"
+	LangDe string = "de"
+)
+
 type Config struct {
 	// Language is an ISO 639 language code like en, ru, de, nl, etc.
-	// Default: "en".
+	// Default: LangEn ("en").
 	Language string
 
-	// Location is the timezone location neeed for parsing
+	// Location is the timezone location needed for parsing
 	// string date like "2019-01-01 00:00:00" to time.Time.
 	// If Location is not set it will default to the server's.
 	// Example: "America/New_York", "Europe/Moscow".

--- a/config_test.go
+++ b/config_test.go
@@ -6,14 +6,40 @@ import (
 )
 
 func TestIsLocationProvided(t *testing.T) {
-	cases := []string{"Europe/Moscow", "UTC", "America/New_York", ""}
+	cases := []struct {
+		name   string
+		loc    string
+		expect bool
+	}{
+		{
+			name:   "Location is set to Europe/Paris",
+			loc:    "Europe/Paris",
+			expect: true,
+		},
+		{
+			name:   "Location is set to Asia/Shanghai",
+			loc:    "Asia/Shanghai",
+			expect: true,
+		},
+		{
+			name:   "Location is not set",
+			loc:    "UTC",
+			expect: false,
+		},
+		{
+			name:   "Location is empty",
+			loc:    "",
+			expect: false,
+		},
+	}
 
 	for _, tc := range cases {
-		t.Run(tc, func(t *testing.T) {
-			c := defaultConfig()
+		t.Run(tc.name, func(t *testing.T) {
+			c := NewConfig("en", tc.loc, []LangSet{}, 60, 60)
+			actual := c.isLocationProvided()
 
-			if !c.isLocationProvided() {
-				t.Fatalf("Expected location to be provided, but got %v", tc)
+			if actual != tc.expect {
+				t.Fatalf("Expected %v, but got %v", tc.expect, actual)
 			}
 		})
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -6,30 +6,14 @@ import (
 )
 
 func TestIsLocationProvided(t *testing.T) {
-	cases := []struct {
-		name   string
-		loc    string
-		expect bool
-	}{
-		{
-			name:   "Location is set",
-			loc:    "Russia/Moscow",
-			expect: true,
-		},
-		{
-			name:   "Location is not set",
-			loc:    "",
-			expect: false,
-		},
-	}
+	cases := []string{"Europe/Moscow", "UTC", "America/New_York", ""}
 
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc, func(t *testing.T) {
 			c := defaultConfig()
-			actual := c.isLocationProvided()
 
-			if actual != tc.expect {
-				t.Fatalf("Expected %v, but got %v", tc.expect, actual)
+			if !c.isLocationProvided() {
+				t.Fatalf("Expected location to be provided, but got %v", tc)
 			}
 		})
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func TestLocationIsSet(t *testing.T) {
+func TestIsLocationProvided(t *testing.T) {
 	cases := []struct {
 		name   string
 		loc    string
@@ -25,7 +25,7 @@ func TestLocationIsSet(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			c := NewConfig("ru", tc.loc, []LangSet{})
+			c := defaultConfig()
 			actual := c.isLocationProvided()
 
 			if actual != tc.expect {

--- a/langs/de.json
+++ b/langs/de.json
@@ -5,32 +5,11 @@
     "online": "Online",
     "justnow": "Soeben",
 
-    "second": {
-        "one": "Sekunde",
-        "other": "Sekunden"
-    },
-    "minute": {
-        "one": "Minute",
-        "other": "Minuten"
-    },
-    "hour": {
-        "one": "Stunde",
-        "other": "Stunden"
-    },
-    "day": {
-        "one": "Tag",
-        "other": "Tagen"
-    },
-    "week": {
-        "one": "Woche",
-        "other": "Wochen"
-    },
-    "month": {
-        "one": "Monat",
-        "other": "Monaten"
-    },
-    "year": {
-        "one": "Jahr",
-        "other": "Jahren"
-    }
+    "second": {"one": "Sekunde", "other": "Sekunden"},
+    "minute": {"one": "Minute", "other": "Minuten"},
+    "hour": {"one": "Stunde", "other": "Stunden"},
+    "day": {"one": "Tag", "other": "Tagen"},
+    "week": {"one": "Woche", "other": "Wochen"},
+    "month": {"one": "Monat", "other": "Monaten"},
+    "year": {"one": "Jahr", "other": "Jahren"}
 }

--- a/langs/en.json
+++ b/langs/en.json
@@ -5,32 +5,11 @@
     "online": "Online",
     "justnow": "Just now",
 
-    "second": {
-        "one": "second",
-        "other": "seconds"
-    },
-    "minute": {
-        "one": "minute",
-        "other": "minutes"
-    },
-    "hour": {
-        "one": "hour",
-        "other": "hours"
-    },
-    "day": {
-        "one": "day",
-        "other": "days"
-    },
-    "week": {
-        "one": "week",
-        "other": "weeks"
-    },
-    "month": {
-        "one": "month",
-        "other": "months"
-    },
-    "year": {
-        "one": "year",
-        "other": "years"
-    }
+    "second": {"one": "second", "other": "seconds"},
+    "minute": {"one": "minute", "other": "minutes"},
+    "hour": {"one": "hour", "other": "hours"},
+    "day": {"one": "day", "other": "days"},
+    "week": {"one": "week", "other": "weeks"},
+    "month": {"one": "month", "other": "months"},
+    "year": {"one": "year", "other": "years"}
 }

--- a/langs/nl.json
+++ b/langs/nl.json
@@ -5,32 +5,11 @@
     "online": "Online",
     "justnow": "Net nu",
 
-    "second": {
-        "one": "seconde",
-        "other": "seconden"
-    },
-    "minute": {
-        "one": "minuut",
-        "other": "minuten"
-    },
-    "hour": {
-        "one": "uur",
-        "other": "uur"
-    },
-    "day": {
-        "one": "dag",
-        "other": "dagen"
-    },
-    "week": {
-        "one": "week",
-        "other": "weken"
-    },
-    "month": {
-        "one": "maand",
-        "other": "maanden"
-    },
-    "year": {
-        "one": "jaar",
-        "other": "jaar"
-    }
+    "second": {"one": "seconde", "other": "seconden"},
+    "minute": {"one": "minuut", "other": "minuten"},
+    "hour": {"one": "uur", "other": "uur"},
+    "day": {"one": "dag", "other": "dagen"},
+    "week": {"one": "week", "other": "weken"},
+    "month": {"one": "maand", "other": "maanden"},
+    "year": {"one": "jaar", "other": "jaar"}
 }

--- a/langs/zh.json
+++ b/langs/zh.json
@@ -1,0 +1,15 @@
+{
+    "lang": "zh",
+    "format": "{num}{timeUnit}{ago}",
+    "ago": "前",
+    "online": "在线",
+    "justnow": "刚刚",
+
+    "second": {"other": "秒"},
+    "minute": {"other": "分钟"},
+    "hour": {"other": "小时"},
+    "day": {"other": "天"},
+    "week": {"other": "周"},
+    "month": {"other": "个月"},
+    "year": {"other": "年"}
+}

--- a/langset.go
+++ b/langset.go
@@ -25,7 +25,6 @@ type LangSet struct {
 
 func newLangSet() (*LangSet, error) {
 	_, filename, _, ok := runtime.Caller(0)
-
 	if !ok {
 		return nil, errorf("No called information")
 	}

--- a/option.go
+++ b/option.go
@@ -10,13 +10,15 @@ const (
 	OptUpcoming opt = "upcoming"
 
 	// Upcoming option displays "OptOnline" if date interval withing
-	// 60 seconds. For example instead of "13 seconds ago"
-	// prints "OptOnline".
+	// the OnlineThreshold provided in config. By default, it's
+	// 60 seconds. For example instead of "13 seconds ago" it will
+	// print "Online".
 	OptOnline opt = "online"
 
 	// OptJustNow option displays "Just now" if date interval withing
-	// 60 seconds. For example instead of "32 seconds ago" prints
-	// "Just now".
+	// the JustNowThreshold provided in config. By default, it's
+	// 60 seconds. For example instead of "32 seconds ago" it will
+	// print "Just now".
 	OptJustNow opt = "justNow"
 
 	// OptNoSuffix option removes suffix from datetime result and get

--- a/option.go
+++ b/option.go
@@ -1,42 +1,42 @@
 package timeago
 
-type Option string
+type opt string
 
 const (
-	// Upcoming option removes the suffix "ago" when the date is
+	// OptUpcoming option removes the suffix "ago" when the date is
 	// in the future. This option is enabled by default, there
 	// is no need to pass it. It's available to keep backward
 	// compatibility with the previous versions.
-	Upcoming Option = "upcoming"
+	OptUpcoming opt = "upcoming"
 
-	// Upcoming option displays "Online" if date interval withing
+	// Upcoming option displays "OptOnline" if date interval withing
 	// 60 seconds. For example instead of "13 seconds ago"
-	// prints "Online".
-	Online Option = "online"
+	// prints "OptOnline".
+	OptOnline opt = "online"
 
-	// JustNow option displays "Just now" if date interval withing
+	// OptJustNow option displays "Just now" if date interval withing
 	// 60 seconds. For example instead of "32 seconds ago" prints
 	// "Just now".
-	JustNow Option = "justNow"
+	OptJustNow opt = "justNow"
 
-	// NoSuffix option removes suffix from datetime result and get
+	// OptNoSuffix option removes suffix from datetime result and get
 	// for example "5 minutes" instead of "5 minutes ago".
-	NoSuffix Option = "noSuffix"
+	OptNoSuffix opt = "noSuffix"
 )
 
-func enableOption(opt Option) {
-	options = append(options, opt)
+func enableOption(o opt) {
+	options = append(options, o)
 }
 
-func enableOptions(opts []Option) {
+func enableOptions(opts []opt) {
 	for _, opt := range opts {
 		enableOption(opt)
 	}
 }
 
-func optionIsEnabled(opt Option) bool {
+func optionIsEnabled(o opt) bool {
 	for _, option := range options {
-		if option == opt {
+		if option == o {
 			return true
 		}
 	}

--- a/option.go
+++ b/option.go
@@ -1,13 +1,28 @@
 package timeago
 
+type Option string
+
 const (
+	// Upcoming option removes the suffix "ago" when the date is
+	// in the future. This option is enabled by default, there
+	// is no need to pass it. It's available to keep backward
+	// compatibility with the previous versions.
 	Upcoming Option = "upcoming"
-	Online   Option = "online"
-	JustNow  Option = "justNow"
+
+	// Upcoming option displays "Online" if date interval withing
+	// 60 seconds. For example instead of "13 seconds ago"
+	// prints "Online".
+	Online Option = "online"
+
+	// JustNow option displays "Just now" if date interval withing
+	// 60 seconds. For example instead of "32 seconds ago" prints
+	// "Just now".
+	JustNow Option = "justNow"
+
+	// NoSuffix option removes suffix from datetime result and get
+	// for example "5 minutes" instead of "5 minutes ago".
 	NoSuffix Option = "noSuffix"
 )
-
-type Option string
 
 func enableOption(opt Option) {
 	options = append(options, opt)

--- a/option_test.go
+++ b/option_test.go
@@ -4,9 +4,9 @@ import "testing"
 
 func TestOptionIsEnabled(t *testing.T) {
 	t.Run("returns true if option is enabled", func(test *testing.T) {
-		options = []Option{"noSuffix"}
+		options = []Option{NoSuffix}
 
-		if res := optionIsEnabled("noSuffix"); res == false {
+		if res := optionIsEnabled(NoSuffix); res == false {
 			test.Error("Result must be true, but got false instead")
 		}
 
@@ -14,9 +14,9 @@ func TestOptionIsEnabled(t *testing.T) {
 	})
 
 	t.Run("returns true if option is enabled with other option", func(test *testing.T) {
-		options = []Option{"noSuffix", "upcoming"}
+		options = []Option{NoSuffix, Upcoming}
 
-		if res := optionIsEnabled("upcoming"); res == false {
+		if res := optionIsEnabled(Upcoming); res == false {
 			test.Error("Result must be true, but got false instead")
 		}
 
@@ -24,7 +24,7 @@ func TestOptionIsEnabled(t *testing.T) {
 	})
 
 	t.Run("returns false if option is disabled", func(test *testing.T) {
-		if res := optionIsEnabled("noSuffix"); res == true {
+		if res := optionIsEnabled(NoSuffix); res == true {
 			test.Error("Result must be true, but got false instead")
 		}
 	})

--- a/option_test.go
+++ b/option_test.go
@@ -4,27 +4,27 @@ import "testing"
 
 func TestOptionIsEnabled(t *testing.T) {
 	t.Run("returns true if option is enabled", func(test *testing.T) {
-		options = []Option{NoSuffix}
+		options = []opt{OptNoSuffix}
 
-		if res := optionIsEnabled(NoSuffix); res == false {
+		if res := optionIsEnabled(OptNoSuffix); res == false {
 			test.Error("Result must be true, but got false instead")
 		}
 
-		options = []Option{}
+		options = []opt{}
 	})
 
 	t.Run("returns true if option is enabled with other option", func(test *testing.T) {
-		options = []Option{NoSuffix, Upcoming}
+		options = []opt{OptNoSuffix, OptUpcoming}
 
-		if res := optionIsEnabled(Upcoming); res == false {
+		if res := optionIsEnabled(OptUpcoming); res == false {
 			test.Error("Result must be true, but got false instead")
 		}
 
-		options = []Option{}
+		options = []opt{}
 	})
 
 	t.Run("returns false if option is disabled", func(test *testing.T) {
-		if res := optionIsEnabled(NoSuffix); res == true {
+		if res := optionIsEnabled(OptNoSuffix); res == true {
 			test.Error("Result must be true, but got false instead")
 		}
 	})

--- a/rules.go
+++ b/rules.go
@@ -31,6 +31,13 @@ var grammarRules = func(num int) map[string]*Rule {
 			Few:  end == 2 || end == 3 || end == 4,
 			Many: (num >= 5 && num <= 20) || end == 0 || (end >= 5 && end <= 9),
 		},
+		"zh": {
+			Zero: true,
+			One:  true,
+			Two:  true,
+			Few:  true,
+			Many: true,
+		},
 	}
 }
 

--- a/tests/de_test.go
+++ b/tests/de_test.go
@@ -4,10 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/SerhiiCho/timeago/v3"
+	ago "github.com/SerhiiCho/timeago/v3"
 )
-
-const langDe = "de"
 
 func TestParseDe(t *testing.T) {
 	cases := []struct {
@@ -61,9 +59,9 @@ func TestParseDe(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run("result for "+tc.date.String(), func(test *testing.T) {
-			timeago.Reconfigure(timeago.Config{Language: langDe})
+			ago.Reconfigure(ago.Config{Language: ago.LangDe})
 
-			res, err := timeago.Parse(tc.date)
+			res, err := ago.Parse(tc.date)
 
 			if err != nil {
 				test.Errorf("Error must be nil, but got %v instead", err)
@@ -97,9 +95,9 @@ func TestParseDeWithSeconds(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run("result for "+tc.date.String(), func(test *testing.T) {
-			timeago.Reconfigure(timeago.Config{Language: langDe})
+			ago.Reconfigure(ago.Config{Language: ago.LangDe})
 
-			res, err := timeago.Parse(tc.date)
+			res, err := ago.Parse(tc.date)
 
 			if err != nil {
 				test.Errorf("Error must be nil, but got %v instead", err)

--- a/tests/en_test.go
+++ b/tests/en_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/SerhiiCho/timeago/v3"
 )
 
-const langEn = "en"
-
 func TestParseEn(t *testing.T) {
 	cases := []struct {
 		date time.Time
@@ -55,7 +53,7 @@ func TestParseEn(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run("result for "+tc.date.String(), func(test *testing.T) {
-			timeago.Reconfigure(timeago.Config{Language: langEn})
+			timeago.Reconfigure(timeago.Config{Language: "en"})
 
 			res, err := timeago.Parse(tc.date)
 
@@ -90,7 +88,7 @@ func TestParseEnWithSeconds(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run("result for "+tc.date.String(), func(test *testing.T) {
-			timeago.Reconfigure(timeago.Config{Language: langEn})
+			timeago.Reconfigure(timeago.Config{Language: "en"})
 
 			res, err := timeago.Parse(tc.date)
 

--- a/tests/just_now_test.go
+++ b/tests/just_now_test.go
@@ -28,7 +28,7 @@ func TestJustNowOption(t *testing.T) {
 		t.Run("result for "+tc.date.String(), func(test *testing.T) {
 			timeago.Reconfigure(timeago.Config{Language: langEn})
 
-			res, err := timeago.Parse(tc.date, "justNow")
+			res, err := timeago.Parse(tc.date, timeago.JustNow)
 
 			if err != nil {
 				test.Errorf("Error must be nil, but got %v instead", err)

--- a/tests/just_now_test.go
+++ b/tests/just_now_test.go
@@ -28,7 +28,7 @@ func TestJustNowOption(t *testing.T) {
 		t.Run("result for "+tc.date.String(), func(test *testing.T) {
 			timeago.Reconfigure(timeago.Config{Language: langEn})
 
-			res, err := timeago.Parse(tc.date, timeago.JustNow)
+			res, err := timeago.Parse(tc.date, timeago.OptJustNow)
 
 			if err != nil {
 				test.Errorf("Error must be nil, but got %v instead", err)

--- a/tests/just_now_test.go
+++ b/tests/just_now_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/SerhiiCho/timeago/v3"
+	ago "github.com/SerhiiCho/timeago/v3"
 )
 
 func TestJustNowOption(t *testing.T) {
@@ -26,9 +26,9 @@ func TestJustNowOption(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run("result for "+tc.date.String(), func(test *testing.T) {
-			timeago.Reconfigure(timeago.Config{Language: langEn})
+			ago.Reconfigure(ago.Config{Language: ago.LangEn})
 
-			res, err := timeago.Parse(tc.date, timeago.OptJustNow)
+			res, err := ago.Parse(tc.date, ago.OptJustNow)
 
 			if err != nil {
 				test.Errorf("Error must be nil, but got %v instead", err)

--- a/tests/multiple_options_test.go
+++ b/tests/multiple_options_test.go
@@ -47,7 +47,7 @@ func TestParseWithMultipleFlags(t *testing.T) {
 		t.Run("result for "+tc.date.String(), func(test *testing.T) {
 			timeago.Reconfigure(timeago.Config{Language: langEn})
 
-			res, err := timeago.Parse(tc.date, timeago.Online, timeago.NoSuffix)
+			res, err := timeago.Parse(tc.date, timeago.OptOnline, timeago.OptNoSuffix)
 
 			if err != nil {
 				test.Errorf("Error must be nil, but got %v instead", err)

--- a/tests/multiple_options_test.go
+++ b/tests/multiple_options_test.go
@@ -47,7 +47,7 @@ func TestParseWithMultipleFlags(t *testing.T) {
 		t.Run("result for "+tc.date.String(), func(test *testing.T) {
 			timeago.Reconfigure(timeago.Config{Language: langEn})
 
-			res, err := timeago.Parse(tc.date, "online", "noSuffix")
+			res, err := timeago.Parse(tc.date, timeago.Online, timeago.NoSuffix)
 
 			if err != nil {
 				test.Errorf("Error must be nil, but got %v instead", err)

--- a/tests/multiple_options_test.go
+++ b/tests/multiple_options_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/SerhiiCho/timeago/v3"
+	ago "github.com/SerhiiCho/timeago/v3"
 )
 
 func TestParseWithMultipleFlags(t *testing.T) {
@@ -45,9 +45,9 @@ func TestParseWithMultipleFlags(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run("result for "+tc.date.String(), func(test *testing.T) {
-			timeago.Reconfigure(timeago.Config{Language: langEn})
+			ago.Reconfigure(ago.Config{Language: ago.LangEn})
 
-			res, err := timeago.Parse(tc.date, timeago.OptOnline, timeago.OptNoSuffix)
+			res, err := ago.Parse(tc.date, ago.OptOnline, ago.OptNoSuffix)
 
 			if err != nil {
 				test.Errorf("Error must be nil, but got %v instead", err)

--- a/tests/nl_test.go
+++ b/tests/nl_test.go
@@ -4,10 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/SerhiiCho/timeago/v3"
+	ago "github.com/SerhiiCho/timeago/v3"
 )
-
-const langNl = "nl"
 
 func TestParseNl(t *testing.T) {
 	cases := []struct {
@@ -61,9 +59,9 @@ func TestParseNl(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run("result for "+tc.date.String(), func(test *testing.T) {
-			timeago.Reconfigure(timeago.Config{Language: langNl})
+			ago.Reconfigure(ago.Config{Language: ago.LangNl})
 
-			res, err := timeago.Parse(tc.date)
+			res, err := ago.Parse(tc.date)
 
 			if err != nil {
 				test.Errorf("Error must be nil, but got %v instead", err)
@@ -97,9 +95,9 @@ func TestParseNlWithSeconds(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run("result for "+tc.date.String(), func(test *testing.T) {
-			timeago.Reconfigure(timeago.Config{Language: langNl})
+			ago.Reconfigure(ago.Config{Language: ago.LangNl})
 
-			res, err := timeago.Parse(tc.date)
+			res, err := ago.Parse(tc.date)
 
 			if err != nil {
 				test.Errorf("Error must be nil, but got %v instead", err)

--- a/tests/no_suffix_test.go
+++ b/tests/no_suffix_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/SerhiiCho/timeago/v3"
+	ago "github.com/SerhiiCho/timeago/v3"
 )
 
 func TestParseWithNoSuffixFlag(t *testing.T) {
@@ -13,61 +13,61 @@ func TestParseWithNoSuffixFlag(t *testing.T) {
 		res  string
 		lang string
 	}{
-		{subMinutes(1), "1 minute", "en"},
-		{subMinutes(2), "2 minutes", "en"},
-		{subMinutes(3), "3 minutes", "en"},
-		{subMinutes(4), "4 minutes", "en"},
-		{subMinutes(5), "5 minutes", "en"},
-		{subMinutes(10), "10 minutes", "en"},
-		{subMinutes(11), "11 minutes", "en"},
-		{subMinutes(20), "20 minutes", "en"},
-		{subMinutes(21), "21 minutes", "en"},
-		{subMinutes(22), "22 minutes", "en"},
-		{subMinutes(30), "30 minutes", "en"},
-		{subMinutes(31), "31 minutes", "en"},
-		{subHours(1), "1 hour", "en"},
-		{subHours(2), "2 hours", "en"},
-		{subHours(9), "9 hours", "en"},
-		{subHours(10), "10 hours", "en"},
-		{subHours(11), "11 hours", "en"},
-		{subHours(20), "20 hours", "en"},
-		{subHours(21), "21 hours", "en"},
-		{subHours(23), "23 hours", "en"},
-		{subDays(1), "1 day", "en"},
-		{subDays(2), "2 days", "en"},
-		{subDays(6), "6 days", "en"},
-		{subWeeks(1), "1 week", "en"},
-		{subWeeks(2), "2 weeks", "en"},
-		{subWeeks(3), "3 weeks", "en"},
-		{subMonths(1), "1 month", "en"},
-		{subMonths(2), "2 months", "en"},
-		{subMonths(3), "3 months", "en"},
-		{subMonths(4), "4 months", "en"},
-		{subMonths(5), "5 months", "en"},
-		{subMonths(6), "6 months", "en"},
-		{subMonths(7), "7 months", "en"},
-		{subMonths(8), "8 months", "en"},
-		{subMonths(9), "9 months", "en"},
-		{subMonths(10), "10 months", "en"},
-		{subMonths(11), "11 months", "en"},
-		{subMonths(12), "1 year", "en"},
-		{subYears(4), "4 years", "en"},
-		{subYears(5), "5 years", "en"},
-		{subYears(11), "11 years", "en"},
-		{subYears(29), "29 years", "en"},
-		{subYears(92), "92 years", "en"},
-		{subMinutes(1), "1 минута", "ru"},
-		{subMinutes(2), "2 минуты", "ru"},
-		{subMonths(3), "3 месяца", "ru"},
-		{subWeeks(2), "2 недели", "ru"},
-		{subYears(77), "77 лет", "ru"},
+		{subMinutes(1), "1 minute", ago.LangEn},
+		{subMinutes(2), "2 minutes", ago.LangEn},
+		{subMinutes(3), "3 minutes", ago.LangEn},
+		{subMinutes(4), "4 minutes", ago.LangEn},
+		{subMinutes(5), "5 minutes", ago.LangEn},
+		{subMinutes(10), "10 minutes", ago.LangEn},
+		{subMinutes(11), "11 minutes", ago.LangEn},
+		{subMinutes(20), "20 minutes", ago.LangEn},
+		{subMinutes(21), "21 minutes", ago.LangEn},
+		{subMinutes(22), "22 minutes", ago.LangEn},
+		{subMinutes(30), "30 minutes", ago.LangEn},
+		{subMinutes(31), "31 minutes", ago.LangEn},
+		{subHours(1), "1 hour", ago.LangEn},
+		{subHours(2), "2 hours", ago.LangEn},
+		{subHours(9), "9 hours", ago.LangEn},
+		{subHours(10), "10 hours", ago.LangEn},
+		{subHours(11), "11 hours", ago.LangEn},
+		{subHours(20), "20 hours", ago.LangEn},
+		{subHours(21), "21 hours", ago.LangEn},
+		{subHours(23), "23 hours", ago.LangEn},
+		{subDays(1), "1 day", ago.LangEn},
+		{subDays(2), "2 days", ago.LangEn},
+		{subDays(6), "6 days", ago.LangEn},
+		{subWeeks(1), "1 week", ago.LangEn},
+		{subWeeks(2), "2 weeks", ago.LangEn},
+		{subWeeks(3), "3 weeks", ago.LangEn},
+		{subMonths(1), "1 month", ago.LangEn},
+		{subMonths(2), "2 months", ago.LangEn},
+		{subMonths(3), "3 months", ago.LangEn},
+		{subMonths(4), "4 months", ago.LangEn},
+		{subMonths(5), "5 months", ago.LangEn},
+		{subMonths(6), "6 months", ago.LangEn},
+		{subMonths(7), "7 months", ago.LangEn},
+		{subMonths(8), "8 months", ago.LangEn},
+		{subMonths(9), "9 months", ago.LangEn},
+		{subMonths(10), "10 months", ago.LangEn},
+		{subMonths(11), "11 months", ago.LangEn},
+		{subMonths(12), "1 year", ago.LangEn},
+		{subYears(4), "4 years", ago.LangEn},
+		{subYears(5), "5 years", ago.LangEn},
+		{subYears(11), "11 years", ago.LangEn},
+		{subYears(29), "29 years", ago.LangEn},
+		{subYears(92), "92 years", ago.LangEn},
+		{subMinutes(1), "1 минута", ago.LangRu},
+		{subMinutes(2), "2 минуты", ago.LangRu},
+		{subMonths(3), "3 месяца", ago.LangRu},
+		{subWeeks(2), "2 недели", ago.LangRu},
+		{subYears(77), "77 лет", ago.LangRu},
 	}
 
 	for _, tc := range cases {
 		t.Run("result for "+tc.date.String(), func(test *testing.T) {
-			timeago.Reconfigure(timeago.Config{Language: tc.lang})
+			ago.Reconfigure(ago.Config{Language: tc.lang})
 
-			res, err := timeago.Parse(tc.date, timeago.OptNoSuffix)
+			res, err := ago.Parse(tc.date, ago.OptNoSuffix)
 
 			if err != nil {
 				test.Errorf("Error must be nil, but got %v instead", err)

--- a/tests/no_suffix_test.go
+++ b/tests/no_suffix_test.go
@@ -67,7 +67,7 @@ func TestParseWithNoSuffixFlag(t *testing.T) {
 		t.Run("result for "+tc.date.String(), func(test *testing.T) {
 			timeago.Reconfigure(timeago.Config{Language: tc.lang})
 
-			res, err := timeago.Parse(tc.date, timeago.NoSuffix)
+			res, err := timeago.Parse(tc.date, timeago.OptNoSuffix)
 
 			if err != nil {
 				test.Errorf("Error must be nil, but got %v instead", err)

--- a/tests/online_test.go
+++ b/tests/online_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/SerhiiCho/timeago/v3"
+	ago "github.com/SerhiiCho/timeago/v3"
 )
 
 func TestParseWithOnlineFlag(t *testing.T) {
@@ -61,11 +61,11 @@ func TestParseWithOnlineFlag(t *testing.T) {
 		cases = append(cases, TestCase{subSeconds(time.Duration(i)), "Online"})
 	}
 
-	timeago.Reconfigure(timeago.Config{Language: langEn})
+	ago.Reconfigure(ago.Config{Language: ago.LangEn})
 
 	for _, tc := range cases {
 		t.Run("result for "+tc.date.String(), func(test *testing.T) {
-			res, err := timeago.Parse(tc.date, timeago.OptOnline)
+			res, err := ago.Parse(tc.date, ago.OptOnline)
 
 			if err != nil {
 				test.Errorf("Error must be nil, but got %v instead", err)
@@ -101,12 +101,12 @@ func TestOnlineThresholdConfiguration(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run("result for "+tc.date.String(), func(test *testing.T) {
-			timeago.Reconfigure(timeago.Config{
-				Language:        langEn,
+			ago.Reconfigure(ago.Config{
+				Language:        ago.LangEn,
 				OnlineThreshold: tc.threshold,
 			})
 
-			out, err := timeago.Parse(tc.date, timeago.OptOnline)
+			out, err := ago.Parse(tc.date, ago.OptOnline)
 
 			if err != nil {
 				test.Errorf("Error must be nil, but got %v instead", err)
@@ -142,12 +142,12 @@ func TestJustNowThresholdConfiguration(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run("result for "+tc.date.String(), func(test *testing.T) {
-			timeago.Reconfigure(timeago.Config{
-				Language:         langRu,
+			ago.Reconfigure(ago.Config{
+				Language:         ago.LangRu,
 				JustNowThreshold: tc.threshold,
 			})
 
-			out, err := timeago.Parse(tc.date, timeago.OptJustNow)
+			out, err := ago.Parse(tc.date, ago.OptJustNow)
 
 			if err != nil {
 				test.Errorf("Error must be nil, but got %v instead", err)

--- a/tests/online_test.go
+++ b/tests/online_test.go
@@ -65,7 +65,7 @@ func TestParseWithOnlineFlag(t *testing.T) {
 		t.Run("result for "+tc.date.String(), func(test *testing.T) {
 			timeago.Reconfigure(timeago.Config{Language: langEn})
 
-			res, err := timeago.Parse(tc.date, timeago.Online)
+			res, err := timeago.Parse(tc.date, timeago.OptOnline)
 
 			if err != nil {
 				test.Errorf("Error must be nil, but got %v instead", err)

--- a/tests/online_test.go
+++ b/tests/online_test.go
@@ -65,7 +65,7 @@ func TestParseWithOnlineFlag(t *testing.T) {
 		t.Run("result for "+tc.date.String(), func(test *testing.T) {
 			timeago.Reconfigure(timeago.Config{Language: langEn})
 
-			res, err := timeago.Parse(tc.date, "online")
+			res, err := timeago.Parse(tc.date, timeago.Online)
 
 			if err != nil {
 				test.Errorf("Error must be nil, but got %v instead", err)

--- a/tests/online_test.go
+++ b/tests/online_test.go
@@ -118,3 +118,44 @@ func TestOnlineThresholdConfiguration(t *testing.T) {
 		})
 	}
 }
+
+func TestJustNowThresholdConfiguration(t *testing.T) {
+	cases := []struct {
+		date      time.Time
+		res       string
+		threshold int
+	}{
+		{subSeconds(10), "Только что", 12},
+		{subSeconds(10), "10 секунд назад", 8},
+		{subSeconds(20), "Только что", 22},
+		{subSeconds(20), "20 секунд назад", 18},
+		{subSeconds(30), "Только что", 32},
+		{subSeconds(30), "30 секунд назад", 28},
+		{subSeconds(40), "Только что", 42},
+		{subSeconds(40), "40 секунд назад", 38},
+		{subSeconds(50), "Только что", 52},
+		{subSeconds(50), "50 секунд назад", 48},
+		{subSeconds(53), "53 секунды назад", 5},
+		{subSeconds(57), "Только что", 60},
+		{subSeconds(57), "57 секунд назад", 55},
+	}
+
+	for _, tc := range cases {
+		t.Run("result for "+tc.date.String(), func(test *testing.T) {
+			timeago.Reconfigure(timeago.Config{
+				Language:         langRu,
+				JustNowThreshold: tc.threshold,
+			})
+
+			out, err := timeago.Parse(tc.date, timeago.OptJustNow)
+
+			if err != nil {
+				test.Errorf("Error must be nil, but got %v instead", err)
+			}
+
+			if out != tc.res {
+				test.Errorf("Result must be %q, but got %q instead", tc.res, out)
+			}
+		})
+	}
+}

--- a/tests/online_test.go
+++ b/tests/online_test.go
@@ -61,10 +61,10 @@ func TestParseWithOnlineFlag(t *testing.T) {
 		cases = append(cases, TestCase{subSeconds(time.Duration(i)), "Online"})
 	}
 
+	timeago.Reconfigure(timeago.Config{Language: langEn})
+
 	for _, tc := range cases {
 		t.Run("result for "+tc.date.String(), func(test *testing.T) {
-			timeago.Reconfigure(timeago.Config{Language: langEn})
-
 			res, err := timeago.Parse(tc.date, timeago.OptOnline)
 
 			if err != nil {
@@ -72,7 +72,48 @@ func TestParseWithOnlineFlag(t *testing.T) {
 			}
 
 			if res != tc.res {
-				test.Errorf("Result must be %s, but got %s instead", tc.res, res)
+				test.Errorf("Result must be %q, but got %q instead", tc.res, res)
+			}
+		})
+	}
+}
+
+func TestOnlineThresholdConfiguration(t *testing.T) {
+	cases := []struct {
+		date      time.Time
+		res       string
+		threshold int
+	}{
+		{subSeconds(10), "Online", 12},
+		{subSeconds(10), "10 seconds ago", 8},
+		{subSeconds(20), "Online", 22},
+		{subSeconds(20), "20 seconds ago", 18},
+		{subSeconds(30), "Online", 32},
+		{subSeconds(30), "30 seconds ago", 28},
+		{subSeconds(40), "Online", 42},
+		{subSeconds(40), "40 seconds ago", 38},
+		{subSeconds(50), "Online", 52},
+		{subSeconds(50), "50 seconds ago", 48},
+		{subSeconds(53), "53 seconds ago", 5},
+		{subSeconds(57), "Online", 60},
+		{subSeconds(57), "57 seconds ago", 55},
+	}
+
+	for _, tc := range cases {
+		t.Run("result for "+tc.date.String(), func(test *testing.T) {
+			timeago.Reconfigure(timeago.Config{
+				Language:        langEn,
+				OnlineThreshold: tc.threshold,
+			})
+
+			out, err := timeago.Parse(tc.date, timeago.OptOnline)
+
+			if err != nil {
+				test.Errorf("Error must be nil, but got %v instead", err)
+			}
+
+			if out != tc.res {
+				test.Errorf("Result must be %q, but got %q instead", tc.res, out)
 			}
 		})
 	}

--- a/tests/ru_test.go
+++ b/tests/ru_test.go
@@ -4,10 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/SerhiiCho/timeago/v3"
+	ago "github.com/SerhiiCho/timeago/v3"
 )
-
-const langRu = "ru"
 
 func TestParseRu(t *testing.T) {
 	cases := []struct {
@@ -56,9 +54,9 @@ func TestParseRu(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run("result for "+tc.date.String(), func(test *testing.T) {
-			timeago.Reconfigure(timeago.Config{Language: langRu})
+			ago.Reconfigure(ago.Config{Language: ago.LangRu})
 
-			res, err := timeago.Parse(tc.date)
+			res, err := ago.Parse(tc.date)
 
 			if err != nil {
 				test.Errorf("Error must be nil, but got %v instead", err)
@@ -92,9 +90,9 @@ func TestParseRuWithSeconds(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run("result for "+tc.date.String(), func(test *testing.T) {
-			timeago.Reconfigure(timeago.Config{Language: langRu})
+			ago.Reconfigure(ago.Config{Language: ago.LangRu})
 
-			res, err := timeago.Parse(tc.date)
+			res, err := ago.Parse(tc.date)
 
 			if err != nil {
 				test.Errorf("Error must be nil, but got %v instead", err)

--- a/tests/upcoming_test.go
+++ b/tests/upcoming_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/SerhiiCho/timeago/v3"
 )
 
-func TestParseWithNoSuffixFlag(t *testing.T) {
+func TestParseWithUpcomingFlag(t *testing.T) {
 	cases := []struct {
 		date time.Time
 		res  string
@@ -67,7 +67,7 @@ func TestParseWithNoSuffixFlag(t *testing.T) {
 		t.Run("result for "+tc.date.String(), func(test *testing.T) {
 			timeago.Reconfigure(timeago.Config{Language: tc.lang})
 
-			res, err := timeago.Parse(tc.date, timeago.NoSuffix)
+			res, err := timeago.Parse(tc.date, timeago.Upcoming)
 
 			if err != nil {
 				test.Errorf("Error must be nil, but got %v instead", err)

--- a/tests/upcoming_test.go
+++ b/tests/upcoming_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/SerhiiCho/timeago/v3"
+	ago "github.com/SerhiiCho/timeago/v3"
 )
 
 func TestParseWithUpcomingFlag(t *testing.T) {
@@ -65,9 +65,9 @@ func TestParseWithUpcomingFlag(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run("result for "+tc.date.String(), func(test *testing.T) {
-			timeago.Reconfigure(timeago.Config{Language: tc.lang})
+			ago.Reconfigure(ago.Config{Language: tc.lang})
 
-			res, err := timeago.Parse(tc.date, timeago.OptUpcoming)
+			res, err := ago.Parse(tc.date, ago.OptUpcoming)
 
 			if err != nil {
 				test.Errorf("Error must be nil, but got %v instead", err)

--- a/tests/upcoming_test.go
+++ b/tests/upcoming_test.go
@@ -67,7 +67,7 @@ func TestParseWithUpcomingFlag(t *testing.T) {
 		t.Run("result for "+tc.date.String(), func(test *testing.T) {
 			timeago.Reconfigure(timeago.Config{Language: tc.lang})
 
-			res, err := timeago.Parse(tc.date, timeago.Upcoming)
+			res, err := timeago.Parse(tc.date, timeago.OptUpcoming)
 
 			if err != nil {
 				test.Errorf("Error must be nil, but got %v instead", err)

--- a/tests/zh_test.go
+++ b/tests/zh_test.go
@@ -1,0 +1,104 @@
+package tests
+
+import (
+	"testing"
+	"time"
+
+	ago "github.com/SerhiiCho/timeago/v3"
+)
+
+func TestParseZh(t *testing.T) {
+	cases := []struct {
+		date time.Time
+		res  string
+	}{
+		{subMinutes(1), "1分钟前"},
+		{subMinutes(2), "2分钟前"},
+		{subMinutes(5), "5分钟前"},
+		{subMinutes(9), "9分钟前"},
+		{subMinutes(10), "10分钟前"},
+		{subMinutes(11), "11分钟前"},
+		{subMinutes(20), "20分钟前"},
+		{subMinutes(21), "21分钟前"},
+		{subMinutes(22), "22分钟前"},
+		{subMinutes(30), "30分钟前"},
+		{subMinutes(31), "31分钟前"},
+		{subMinutes(59), "59分钟前"},
+		{subHours(1), "1小时前"},
+		{subHours(2), "2小时前"},
+		{subHours(9), "9小时前"},
+		{subHours(10), "10小时前"},
+		{subHours(11), "11小时前"},
+		{subHours(20), "20小时前"},
+		{subHours(21), "21小时前"},
+		{subHours(23), "23小时前"},
+		{subDays(1), "1天前"},
+		{subDays(2), "2天前"},
+		{subDays(4), "4天前"},
+		{subDays(5), "5天前"},
+		{subDays(6), "6天前"},
+		{subWeeks(1), "1周前"},
+		{subWeeks(2), "2周前"},
+		{subWeeks(3), "3周前"},
+		{subMonths(1), "1个月前"},
+		{subMonths(2), "2个月前"},
+		{subMonths(9), "9个月前"},
+		{subMonths(11), "11个月前"},
+		{subYears(1), "1年前"},
+		{subYears(2), "2年前"},
+		{subYears(21), "21年前"},
+		{subYears(31), "31年前"},
+		{subYears(100), "100年前"},
+	}
+
+	for _, tc := range cases {
+		t.Run("result for "+tc.date.String(), func(test *testing.T) {
+			ago.Reconfigure(ago.Config{Language: ago.LangZh})
+
+			res, err := ago.Parse(tc.date)
+
+			if err != nil {
+				test.Errorf("Error must be nil, but got %v instead", err)
+			}
+
+			if res != tc.res {
+				test.Errorf("Result must be %s, but got %s instead", tc.res, res)
+			}
+		})
+	}
+}
+
+func TestParseZhWithSeconds(t *testing.T) {
+	cases := []struct {
+		date time.Time
+		res  []string
+	}{
+		{subSeconds(0), []string{"0秒前", "1秒前"}},
+		{subSeconds(1), []string{"1秒前", "2秒前"}},
+		{subSeconds(2), []string{"2秒前", "3秒前"}},
+		{subSeconds(9), []string{"9秒前", "10秒前"}},
+		{subSeconds(10), []string{"10秒前", "11秒前"}},
+		{subSeconds(11), []string{"11秒前", "12秒前"}},
+		{subSeconds(20), []string{"20秒前", "21秒前"}},
+		{subSeconds(21), []string{"21秒前", "22秒前"}},
+		{subSeconds(22), []string{"22秒前", "23秒前"}},
+		{subSeconds(30), []string{"30秒前", "31秒前"}},
+		{subSeconds(59), []string{"59秒前", "1分钟前"}},
+	}
+
+	for _, tc := range cases {
+		t.Run("result for "+tc.date.String(), func(test *testing.T) {
+			ago.Reconfigure(ago.Config{Language: ago.LangZh})
+
+			res, err := ago.Parse(tc.date)
+
+			if err != nil {
+				test.Errorf("Error must be nil, but got %v instead", err)
+			}
+
+			if res != tc.res[0] && res != tc.res[1] {
+				test.Errorf("Result must be %s or %s, but got %s instead", tc.res[0], tc.res[1], res)
+			}
+		})
+	}
+}

--- a/timeago.go
+++ b/timeago.go
@@ -14,7 +14,7 @@ var (
 
 	// options is a list of options that modify the final output.
 	// Some options are noSuffix, upcoming, online, and justNow.
-	options = []Option{}
+	options = []opt{}
 
 	// conf is configuration provided by the user.
 	conf = defaultConfig()
@@ -39,8 +39,8 @@ type timeNumbers struct {
 // 1. int (Unix timestamp)
 // 2. time.Time (Type from Go time package)
 // 3. string (Datetime string in format 'YYYY-MM-DD HH:MM:SS')
-func Parse(datetime interface{}, opts ...Option) (string, error) {
-	options = []Option{}
+func Parse(datetime interface{}, opts ...opt) (string, error) {
+	options = []opt{}
 	langSet = nil
 
 	var input time.Time
@@ -142,11 +142,11 @@ func computeTimeSince(t time.Time) (string, error) {
 		return "", err
 	}
 
-	if optionIsEnabled(Online) && timeInSec < 60 {
+	if optionIsEnabled(OptOnline) && timeInSec < 60 {
 		return langSet.Online, nil
 	}
 
-	if optionIsEnabled(JustNow) && timeInSec < 60 {
+	if optionIsEnabled(OptJustNow) && timeInSec < 60 {
 		return langSet.JustNow, nil
 	}
 
@@ -181,7 +181,7 @@ func adjustTimesForLocation(t, now time.Time) (time.Time, time.Time, error) {
 func computeTimeDifference(t, now time.Time) int {
 	timeInSec := int(now.Sub(t).Seconds())
 	if timeInSec < 0 {
-		enableOption(Upcoming)
+		enableOption(OptUpcoming)
 		return -timeInSec
 	}
 
@@ -226,7 +226,7 @@ func findLangForms(timeInSec int) (LangForms, int) {
 }
 
 func computeSuffix() string {
-	if optionIsEnabled(NoSuffix) || optionIsEnabled(Upcoming) {
+	if optionIsEnabled(OptNoSuffix) || optionIsEnabled(OptUpcoming) {
 		return ""
 	}
 

--- a/timeago.go
+++ b/timeago.go
@@ -1,6 +1,7 @@
 package timeago
 
 import (
+	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -150,11 +151,14 @@ func computeTimeSince(t time.Time) (string, error) {
 		return "", err
 	}
 
-	if optionIsEnabled(OptOnline) && timeInSec < 60 {
+	fmt.Printf("-------> %#v\n", timeInSec)
+	fmt.Printf("-------> %#v\n", timeInSec < conf.OnlineThreshold)
+
+	if optionIsEnabled(OptOnline) && timeInSec < conf.OnlineThreshold {
 		return langSet.Online, nil
 	}
 
-	if optionIsEnabled(OptJustNow) && timeInSec < 60 {
+	if optionIsEnabled(OptJustNow) && timeInSec < conf.JustNowThreshold {
 		return langSet.JustNow, nil
 	}
 

--- a/timeago.go
+++ b/timeago.go
@@ -1,7 +1,6 @@
 package timeago
 
 import (
-	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -150,9 +149,6 @@ func computeTimeSince(t time.Time) (string, error) {
 	if langSet, err = newLangSet(); err != nil {
 		return "", err
 	}
-
-	fmt.Printf("-------> %#v\n", timeInSec)
-	fmt.Printf("-------> %#v\n", timeInSec < conf.OnlineThreshold)
 
 	if optionIsEnabled(OptOnline) && timeInSec < conf.OnlineThreshold {
 		return langSet.Online, nil

--- a/timeago.go
+++ b/timeago.go
@@ -69,6 +69,14 @@ func Parse(datetime interface{}, opts ...opt) (string, error) {
 // provided configuration. If you want to override the previous
 // configurations, use Reconfigure function instead.
 func Configure(c Config) {
+	if c.OnlineThreshold > 0 {
+		conf.OnlineThreshold = c.OnlineThreshold
+	}
+
+	if c.JustNowThreshold > 0 {
+		conf.JustNowThreshold = c.JustNowThreshold
+	}
+
 	if c.Language != "" {
 		conf.Language = c.Language
 	}
@@ -91,7 +99,7 @@ func Reconfigure(c Config) {
 }
 
 func defaultConfig() *Config {
-	return NewConfig("en", "", []LangSet{})
+	return NewConfig("en", "UTC", []LangSet{}, 60, 60)
 }
 
 func strToTime(datetime string) (time.Time, error) {

--- a/timeago.go
+++ b/timeago.go
@@ -24,6 +24,16 @@ var (
 	langSet *LangSet
 )
 
+type timeNumbers struct {
+	Seconds int
+	Minutes int
+	Hours   int
+	Days    int
+	Weeks   int
+	Months  int
+	Years   int
+}
+
 // Parse coverts privided datetime into `x time ago` format.
 // The first argument can have 3 types:
 // 1. int (Unix timestamp)
@@ -77,7 +87,6 @@ func Configure(c Config) {
 func Reconfigure(c Config) {
 	conf = defaultConfig()
 	cachedJsonRes = map[string]*LangSet{}
-
 	Configure(c)
 }
 
@@ -92,13 +101,11 @@ func strToTime(datetime string) (time.Time, error) {
 	}
 
 	loc, err := location()
-
 	if err != nil {
 		return time.Time{}, err
 	}
 
 	parsedTime, err := time.ParseInLocation("2006-01-02 15:04:05", datetime, loc)
-
 	if err != nil {
 		return time.Time{}, errorf("%v", err)
 	}
@@ -113,7 +120,6 @@ func location() (*time.Location, error) {
 	}
 
 	loc, err := time.LoadLocation(conf.Location)
-
 	if err != nil {
 		return nil, errorf("%v", err)
 	}
@@ -123,90 +129,131 @@ func location() (*time.Location, error) {
 
 func computeTimeSince(t time.Time) (string, error) {
 	now := time.Now()
+	var err error
 
-	if conf.isLocationProvided() {
-		loc, err := location()
-
-		if err != nil {
-			return "", err
-		}
-
-		t = t.In(loc)
-		now = now.In(loc)
-	}
-
-	seconds := int(now.Sub(t).Seconds())
-
-	if seconds < 0 {
-		enableOption(Upcoming)
-		seconds = -seconds
-	}
-
-	set, err := newLangSet()
-
-	if err != nil {
+	// Adjust times based on location if provided
+	if t, now, err = adjustTimesForLocation(t, now); err != nil {
 		return "", err
 	}
 
-	langSet = set
+	timeInSec := computeTimeDifference(t, now)
 
-	return computeTimeUnit(seconds)
+	if langSet, err = newLangSet(); err != nil {
+		return "", err
+	}
+
+	if optionIsEnabled("online") && timeInSec < 60 {
+		return langSet.Online, nil
+	}
+
+	if optionIsEnabled("justNow") && timeInSec < 60 {
+		return langSet.JustNow, nil
+	}
+
+	var timeUnit string
+
+	langForms, timeNum := findLangForms(timeInSec)
+
+	if timeUnit, err = computeTimeUnit(langForms, timeNum); err != nil {
+		return "", err
+	}
+
+	suffix := computeSuffix()
+
+	return mergeFinalOutput(timeNum, timeUnit, suffix)
 }
 
-func computeTimeUnit(seconds int) (string, error) {
-	minutes, hours, days, weeks, months, years := timeCalculations(float64(seconds))
+// adjustTimesForLocation adjusts the given times based on the provided location.
+func adjustTimesForLocation(t, now time.Time) (time.Time, time.Time, error) {
+	if !conf.isLocationProvided() {
+		return t, now, nil
+	}
+
+	loc, err := location()
+	if err != nil {
+		return t, now, err
+	}
+
+	return t.In(loc), now.In(loc), nil
+}
+
+// computeTimeDifference returns the absolute time difference in seconds.
+func computeTimeDifference(t, now time.Time) int {
+	timeInSec := int(now.Sub(t).Seconds())
+	if timeInSec < 0 {
+		enableOption(Upcoming)
+		return -timeInSec
+	}
+
+	return timeInSec
+}
+
+func mergeFinalOutput(timeNum int, timeUnit, suffix string) (string, error) {
+	replacer := strings.NewReplacer(
+		"{timeUnit}", timeUnit,
+		"{num}", strconv.Itoa(timeNum),
+		"{ago}", suffix,
+	)
+
+	out := replacer.Replace(langSet.Format)
+
+	return strings.TrimSpace(out), nil
+}
+
+func findLangForms(timeInSec int) (LangForms, int) {
+	nums := calculateTimeNumbers(float64(timeInSec))
 
 	switch {
-	case optionIsEnabled("online") && seconds < 60:
-		return langSet.Online, nil
-	case optionIsEnabled("justNow") && seconds < 60:
-		return langSet.JustNow, nil
-	case seconds < 60:
-		return timeUnits(langSet.Second, seconds)
-	case minutes < 60:
-		return timeUnits(langSet.Minute, minutes)
-	case hours < 24:
-		return timeUnits(langSet.Hour, hours)
-	case days < 7:
-		return timeUnits(langSet.Day, days)
-	case weeks < 4:
-		return timeUnits(langSet.Week, weeks)
-	case months < 12:
-		if months == 0 {
-			months = 1
+	case timeInSec < 60:
+		return langSet.Second, nums.Seconds
+	case nums.Minutes < 60:
+		return langSet.Minute, nums.Minutes
+	case nums.Hours < 24:
+		return langSet.Hour, nums.Hours
+	case nums.Days < 7:
+		return langSet.Day, nums.Days
+	case nums.Weeks < 4:
+		return langSet.Week, nums.Weeks
+	case nums.Months < 12:
+		if nums.Months == 0 {
+			nums.Months = 1
 		}
 
-		return timeUnits(langSet.Month, months)
+		return langSet.Month, nums.Months
 	}
 
-	return timeUnits(langSet.Year, years)
+	return langSet.Year, nums.Years
 }
 
-// timeUnits decides rather the word must be singular or plural,
-// and depending on the result it adds the correct word after
-// the time number.
-func timeUnits(langForm LangForms, num int) (string, error) {
-	timeUnit, err := finalTimeUnit(langForm, num)
-
-	if err != nil {
-		return "", err
-	}
-
-	res := langSet.Format
-	res = strings.Replace(res, "{timeUnit}", timeUnit, -1)
-	res = strings.Replace(res, "{num}", strconv.Itoa(num), -1)
-
+func computeSuffix() string {
 	if optionIsEnabled("noSuffix") || optionIsEnabled("upcoming") {
-		res = strings.Replace(res, "{ago}", "", -1)
-		return strings.Trim(res, " "), nil
+		return ""
 	}
 
-	return strings.Replace(res, "{ago}", langSet.Ago, -1), nil
+	return langSet.Ago
 }
 
-func finalTimeUnit(langForm LangForms, num int) (string, error) {
-	form, err := timeUnitForm(num)
+func calculateTimeNumbers(seconds float64) timeNumbers {
+	minutes := math.Round(seconds / 60)
+	hours := math.Round(seconds / 3600)
+	days := math.Round(seconds / 86400)
+	weeks := math.Round(seconds / 604800)
+	months := math.Round(seconds / 2629440)
+	years := math.Round(seconds / 31553280)
 
+	return timeNumbers{
+		Seconds: int(seconds),
+		Minutes: int(minutes),
+		Hours:   int(hours),
+		Days:    int(days),
+		Weeks:   int(weeks),
+		Months:  int(months),
+		Years:   int(years),
+	}
+}
+
+func computeTimeUnit(langForm LangForms, num int) (string, error) {
+	form, err := timeUnitForm(num)
 	if err != nil {
 		return "", err
 	}
@@ -220,7 +267,6 @@ func finalTimeUnit(langForm LangForms, num int) (string, error) {
 
 func timeUnitForm(num int) (string, error) {
 	rule, err := identifyGrammarRules(num, conf.Language)
-
 	if err != nil {
 		return "", err
 	}
@@ -239,15 +285,4 @@ func timeUnitForm(num int) (string, error) {
 	}
 
 	return "other", nil
-}
-
-func timeCalculations(seconds float64) (int, int, int, int, int, int) {
-	minutes := math.Round(seconds / 60)
-	hours := math.Round(seconds / 3600)
-	days := math.Round(seconds / 86400)
-	weeks := math.Round(seconds / 604800)
-	months := math.Round(seconds / 2629440)
-	years := math.Round(seconds / 31553280)
-
-	return int(minutes), int(hours), int(days), int(weeks), int(months), int(years)
 }

--- a/timeago.go
+++ b/timeago.go
@@ -142,11 +142,11 @@ func computeTimeSince(t time.Time) (string, error) {
 		return "", err
 	}
 
-	if optionIsEnabled("online") && timeInSec < 60 {
+	if optionIsEnabled(Online) && timeInSec < 60 {
 		return langSet.Online, nil
 	}
 
-	if optionIsEnabled("justNow") && timeInSec < 60 {
+	if optionIsEnabled(JustNow) && timeInSec < 60 {
 		return langSet.JustNow, nil
 	}
 
@@ -226,7 +226,7 @@ func findLangForms(timeInSec int) (LangForms, int) {
 }
 
 func computeSuffix() string {
-	if optionIsEnabled("noSuffix") || optionIsEnabled("upcoming") {
+	if optionIsEnabled(NoSuffix) || optionIsEnabled(Upcoming) {
 		return ""
 	}
 

--- a/utils.go
+++ b/utils.go
@@ -27,7 +27,6 @@ func parseLangSet(fileName string) *LangSet {
 	var res LangSet
 
 	err := json.Unmarshal(content, &res)
-
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -37,7 +36,6 @@ func parseLangSet(fileName string) *LangSet {
 
 func readFile(filePath string) []byte {
 	content, err := os.ReadFile(filePath)
-
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -47,7 +45,6 @@ func readFile(filePath string) []byte {
 
 func isFilePresent(filePath string) (bool, error) {
 	_, err := os.Stat(filePath)
-
 	if err == nil {
 		return true, nil
 	}


### PR DESCRIPTION
- Updated the `LICENSE.md` file
- Refactored codebase to make it more readable and maintainable
- Added [OnlineThreshold](https://time-ago.github.io/v3/configurations.html#thresholds) parameter to the configurations to set the threshold for the "Online" status
- Added [JustNowThreshold](https://time-ago.github.io/v3/configurations.html#thresholds) parameter to the configurations to set the threshold for the "Just now" status
- Added support for Chinese Simplified language 🇨🇳
- **POTENTIAL BREAK**. Might break your code if you were using the `Option` type or option constants directly. Which wasn't documented for public use.
    - Rename `Option` type to `opt` making it unexported
    - Add prefix to option constants `Opt` to make them like `OptOnline`, `OptNoSuffix`, etc.