### PR TITLE
V3.2.2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go_version: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22', '1.23']
+        go_version: ['1.16', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22', '1.23']
 
     steps:
     - name: Check out code into the Go module directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes v3
 
+## v3.2.2 (2025-06-04)
+- Remove support for go version 1.13, 1.14, 1.15 because they do not have `go:embed`
+
 ## v3.2.1 (2024-12-06)
 - Bug fix with incorrect Russian, Ukrainian, and Belarusian languages rules
 - Added more tests for Russian, Ukrainian, and Belarusian languages for testing seconds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release Notes v3
 
 ## v3.2.2 (2025-06-04)
+- Change so that all JSON files are included in the final binary by using `go:embed` functionality
 - Remove support for go version 1.13, 1.14, 1.15 because they do not have `go:embed`
 
 ## v3.2.1 (2024-12-06)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/SerhiiCho/timeago/v3
 
-go 1.13
+go 1.16

--- a/langset.go
+++ b/langset.go
@@ -32,7 +32,7 @@ func newLangSet() (*LangSet, error) {
 		return cache, nil
 	}
 
-	langSet, err := parseLangSet(filePath, langsFS)
+	langSet, err := parseLangSet(filePath)
 	if err != nil {
 		return nil, err
 	}

--- a/langset.go
+++ b/langset.go
@@ -1,12 +1,12 @@
 package timeago
 
 import (
+	"embed"
 	"fmt"
-	"path"
-	"runtime"
-
-	"github.com/SerhiiCho/timeago/v3/internal/utils"
 )
+
+//go:embed langs/*.json
+var langsFS embed.FS
 
 type LangForms map[string]string
 
@@ -26,19 +26,17 @@ type LangSet struct {
 }
 
 func newLangSet() (*LangSet, error) {
-	_, filename, _, ok := runtime.Caller(0)
-	if !ok {
-		return nil, utils.Errorf("No called information")
-	}
-
-	rootPath := path.Dir(filename)
-	filePath := fmt.Sprintf(rootPath+"/langs/%s.json", conf.Language)
+	filePath := fmt.Sprintf("langs/%s.json", conf.Language)
 
 	if cache, ok := cachedJsonRes[filePath]; ok {
 		return cache, nil
 	}
 
-	langSet := parseLangSet(filePath)
+	langSet, err := parseLangSet(filePath, langsFS)
+	if err != nil {
+		return nil, err
+	}
+
 	langSet = applyCustomTranslations(langSet)
 
 	cachedJsonRes[filePath] = langSet

--- a/utils.go
+++ b/utils.go
@@ -2,10 +2,7 @@ package timeago
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
-	"log"
-	"os"
 	"time"
 )
 
@@ -26,26 +23,4 @@ func parseLangSet(filePath string) (*LangSet, error) {
 	}
 
 	return langSet, nil
-}
-
-func readFile(filePath string) []byte {
-	content, err := os.ReadFile(filePath)
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	return content
-}
-
-func isFilePresent(filePath string) (bool, error) {
-	_, err := os.Stat(filePath)
-	if err == nil {
-		return true, nil
-	}
-
-	if errors.Is(err, os.ErrNotExist) {
-		return false, nil
-	}
-
-	return false, err
 }

--- a/utils.go
+++ b/utils.go
@@ -1,7 +1,6 @@
 package timeago
 
 import (
-	"embed"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,7 +13,7 @@ func unixToTime(userDate int) time.Time {
 	return time.Unix(int64(userDate), 0)
 }
 
-func parseLangSet(filePath string, fs embed.FS) (*LangSet, error) {
+func parseLangSet(filePath string) (*LangSet, error) {
 	content, err := langsFS.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("could not read language file: %w", err)

--- a/utils.go
+++ b/utils.go
@@ -1,8 +1,10 @@
 package timeago
 
 import (
+	"embed"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"os"
 	"time"
@@ -12,17 +14,19 @@ func unixToTime(userDate int) time.Time {
 	return time.Unix(int64(userDate), 0)
 }
 
-func parseLangSet(fileName string) *LangSet {
-	content := readFile(fileName)
-
-	var res LangSet
-
-	err := json.Unmarshal(content, &res)
+func parseLangSet(filePath string, fs embed.FS) (*LangSet, error) {
+	content, err := langsFS.ReadFile(filePath)
 	if err != nil {
-		log.Fatalln(err)
+		return nil, fmt.Errorf("could not read language file: %w", err)
 	}
 
-	return &res
+	langSet := &LangSet{}
+
+	if err := json.Unmarshal(content, &langSet); err != nil {
+		return nil, fmt.Errorf("could not unmarshal language file: %w", err)
+	}
+
+	return langSet, nil
 }
 
 func readFile(filePath string) []byte {

--- a/utils_test.go
+++ b/utils_test.go
@@ -7,7 +7,11 @@ import (
 
 func TestParseJsonIntoLang(t *testing.T) {
 	t.Run("Function returns Lang model with needed values", func(test *testing.T) {
-		res := parseLangSet("langs/ru.json")
+		res, err := parseLangSet("langs/ru.json", langsFS)
+
+		if err != nil {
+			t.Errorf("Function parseLangSet must return Lang model, but returned error %v", err)
+		}
 
 		if res.Ago != "назад" {
 			t.Errorf("Function needs to return model with value назад, but returned %v", res.Ago)

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,7 +1,6 @@
 package timeago
 
 import (
-	"encoding/json"
 	"testing"
 )
 
@@ -15,41 +14,6 @@ func TestParseJsonIntoLang(t *testing.T) {
 
 		if res.Ago != "назад" {
 			t.Errorf("Function needs to return model with value назад, but returned %v", res.Ago)
-		}
-	})
-}
-
-func TestIsFilePresent(t *testing.T) {
-	t.Run("isFilePresent return false if file doesn't exist", func(test *testing.T) {
-		res, _ := isFilePresent("somerandompath")
-
-		if res {
-			t.Error("isFilePresent must return false, because filepath points to a file that doesn't exist")
-		}
-	})
-
-	t.Run("isFilePresent return true if file exist", func(test *testing.T) {
-		ok, err := isFilePresent("timeago.go")
-
-		if err != nil {
-			t.Errorf("isFilePresent must return true, because filepath points to a file that exists, but returned error %v", err)
-		}
-
-		if !ok {
-			t.Error("isFilePresent must return true, because filepath points to a file that exists")
-		}
-	})
-}
-
-func TestReadFile(t *testing.T) {
-	t.Run("readFile returns content of the file", func(test *testing.T) {
-		res := readFile("langs/en.json")
-
-		var js json.RawMessage
-		err := json.Unmarshal(res, &js)
-
-		if err != nil {
-			t.Errorf("Function readFile must return JSON object but %s returned", string(res))
 		}
 	})
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestParseJsonIntoLang(t *testing.T) {
 	t.Run("Function returns Lang model with needed values", func(test *testing.T) {
-		res, err := parseLangSet("langs/ru.json", langsFS)
+		res, err := parseLangSet("langs/ru.json")
 
 		if err != nil {
 			t.Errorf("Function parseLangSet must return Lang model, but returned error %v", err)


### PR DESCRIPTION
- Change so that all JSON files are included in the final binary by using `go:embed` functionality
- Remove support for go version 1.13, 1.14, 1.15 because they do not have `go:embed`

fixes #44